### PR TITLE
METRICS-516: Adding Resource labels in OpenCensus Extension

### DIFF
--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
@@ -21,6 +21,7 @@ package org.apache.druid.data.input.opencensus.protobuf;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
@@ -39,6 +40,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -95,104 +97,104 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
       Set<String> recordDimensions = metric.getMetricDescriptor().getLabelKeysList().stream()
           .map(s -> s.getKey())
           .collect(Collectors.toSet());
+
+      // Add resource map key set to record dimensions. Do not check for null behavior of
+      // getResource() and getLabelsMap() as default instance or empty map will be returned
+      // respectively. Hence it's safe to call methods directly without null check.
+      recordDimensions.addAll(metric.getResource().getLabelsMap().keySet());
+
+      // NAME, VALUE dimensions will not be present in labelKeysList or Metric.Resource map as they
+      // are derived dimensions, which get populated while parsing data for timeSeries hence add
+      // them to recordDimensions.
       recordDimensions.add(NAME);
       recordDimensions.add(VALUE);
-
 
       dimensions = Lists.newArrayList(
           Sets.difference(recordDimensions, parseSpec.getDimensionsSpec().getDimensionExclusions())
       );
     }
 
+    // Create immutable resourceLabels which are common to all points in timeSeries. It's safe to
+    // call getResource() and getLabelsMap() methods without null check.
+    Map<String, String> resourceLabels = ImmutableMap.copyOf(metric.getResource().getLabelsMap());
+
     // Flatten out the OpenCensus record into druid rows.
     List<InputRow> rows = new ArrayList<>();
     for (TimeSeries ts : metric.getTimeseriesList()) {
 
-      HashMap<String, Object> labels = new HashMap<>();
+      // Add common resourceLabels.
+      Map<String, Object> labels = new HashMap<>(resourceLabels);
 
       // Add labels to record.
       for (int i = 0; i < metric.getMetricDescriptor().getLabelKeysCount(); i++) {
         labels.put(metric.getMetricDescriptor().getLabelKeys(i).getKey(), ts.getLabelValues(i).getValue());
       }
 
-      // One row per timeseries- point.
+      // One row per timeSeries point.
       for (Point point : ts.getPointsList()) {
         // Time in millis
         labels.put(TIMESTAMP_COLUMN, point.getTimestamp().getSeconds() * 1000);
 
+        List<Map<String, Object>> derivedMetricsList = new ArrayList<>();
         switch (point.getValueCase()) {
           case DOUBLE_VALUE:
-            HashMap<String, Object> doubleGauge = new HashMap<>();
+            Map<String, Object> doubleGauge = new HashMap<>();
             doubleGauge.putAll(labels);
             doubleGauge.put(NAME, metric.getMetricDescriptor().getName());
             doubleGauge.put(VALUE, point.getDoubleValue());
-            rows.add(new MapBasedInputRow(
-                parseSpec.getTimestampSpec().extractTimestamp(doubleGauge),
-                dimensions,
-                doubleGauge
-            ));
+            derivedMetricsList.add(doubleGauge);
             break;
           case INT64_VALUE:
             HashMap<String, Object> intGauge = new HashMap<>();
             intGauge.putAll(labels);
             intGauge.put(VALUE, point.getInt64Value());
             intGauge.put(NAME, metric.getMetricDescriptor().getName());
-            rows.add(new MapBasedInputRow(
-                parseSpec.getTimestampSpec().extractTimestamp(intGauge),
-                dimensions,
-                intGauge
-            ));
+            derivedMetricsList.add(intGauge);
             break;
           case SUMMARY_VALUE:
             // count
-            HashMap<String, Object> summaryCount = new HashMap<>();
+            Map<String, Object> summaryCount = new HashMap<>();
             summaryCount.putAll(labels);
             summaryCount.put(NAME, metric.getMetricDescriptor().getName() + SEPARATOR + "count");
             summaryCount.put(VALUE, point.getSummaryValue().getCount().getValue());
-            rows.add(new MapBasedInputRow(
-                parseSpec.getTimestampSpec().extractTimestamp(summaryCount),
-                dimensions,
-                summaryCount
-            ));
+            derivedMetricsList.add(summaryCount);
 
             // sum
-            HashMap<String, Object> summarySum = new HashMap<>();
+            Map<String, Object> summarySum = new HashMap<>();
             summarySum.putAll(labels);
             summarySum.put(NAME, metric.getMetricDescriptor().getName() + SEPARATOR + "sum");
             summarySum.put(VALUE, point.getSummaryValue().getSnapshot().getSum().getValue());
-            rows.add(new MapBasedInputRow(
-                parseSpec.getTimestampSpec().extractTimestamp(summarySum),
-                dimensions,
-                summarySum
-            ));
+            derivedMetricsList.add(summarySum);
 
             // TODO : Do we put percentiles into druid ?
             break;
           case DISTRIBUTION_VALUE:
             // count
-            HashMap<String, Object> distCount = new HashMap<>();
+            Map<String, Object> distCount = new HashMap<>();
             distCount.put(NAME, metric.getMetricDescriptor().getName() + SEPARATOR + "count");
             distCount.put(VALUE, point.getDistributionValue().getCount());
-            rows.add(new MapBasedInputRow(
-                parseSpec.getTimestampSpec().extractTimestamp(distCount),
-                dimensions,
-                distCount
-            ));
+            derivedMetricsList.add(distCount);
 
             // sum
-            HashMap<String, Object> distSum = new HashMap<>();
+            Map<String, Object> distSum = new HashMap<>();
             distSum.put(NAME, metric.getMetricDescriptor().getName() + SEPARATOR + "sum");
             distSum.put(VALUE, point.getDistributionValue().getSum());
-            rows.add(new MapBasedInputRow(
-                parseSpec.getTimestampSpec().extractTimestamp(distSum),
-                dimensions,
-                distSum
-            ));
+            derivedMetricsList.add(distSum);
             // TODO: How to handle buckets ?
             break;
         }
+
+        // Add druid rows based on derivedMetrics list.
+        for (Map<String, Object> derivedMetrics : derivedMetricsList) {
+          rows.add(new MapBasedInputRow(
+              parseSpec.getTimestampSpec().extractTimestamp(derivedMetrics),
+              dimensions,
+              derivedMetrics
+          ));
+        }
       }
     }
+
     return rows;
   }
 

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
@@ -21,7 +21,6 @@ package org.apache.druid.data.input.opencensus.protobuf;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
@@ -98,9 +97,7 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
           .map(s -> s.getKey())
           .collect(Collectors.toSet());
 
-      // Add resource map key set to record dimensions. Do not check for null behavior of
-      // getResource() and getLabelsMap() as default instance or empty map will be returned
-      // respectively. Hence it's safe to call methods directly without null check.
+      // Add resource map key set to record dimensions.
       recordDimensions.addAll(metric.getResource().getLabelsMap().keySet());
 
       // NAME, VALUE dimensions will not be present in labelKeysList or Metric.Resource map as they
@@ -114,16 +111,12 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
       );
     }
 
-    // Create immutable resourceLabels which are common to all points in timeSeries. It's safe to
-    // call getResource() and getLabelsMap() methods without null check.
-    Map<String, String> resourceLabels = ImmutableMap.copyOf(metric.getResource().getLabelsMap());
-
     // Flatten out the OpenCensus record into druid rows.
     List<InputRow> rows = new ArrayList<>();
     for (TimeSeries ts : metric.getTimeseriesList()) {
 
       // Add common resourceLabels.
-      Map<String, Object> labels = new HashMap<>(resourceLabels);
+      Map<String, Object> labels = new HashMap<>(metric.getResource().getLabelsMap());
 
       // Add labels to record.
       for (int i = 0; i < metric.getMetricDescriptor().getLabelKeysCount(); i++) {

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
@@ -110,9 +110,9 @@ public class OpenCensusProtobufInputRowParserTest
 
     System.out.println(timestamp.getSeconds() * 1000);
 
-    Metric d = doubleGaugeMetric(timestamp);
+    Metric metric = doubleGaugeMetric(timestamp);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    d.writeTo(out);
+    metric.writeTo(out);
 
     InputRow row = parser.parseBatch(ByteBuffer.wrap(out.toByteArray())).get(0);
     Assert.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
@@ -135,9 +135,9 @@ public class OpenCensusProtobufInputRowParserTest
     Timestamp timestamp = Timestamp.newBuilder().setSeconds(dateTime.getMillis() / 1000)
         .setNanos((int) ((dateTime.getMillis() % 1000) * 1000000)).build();
 
-    Metric d = summaryMetric(timestamp);
+    Metric metric = summaryMetric(timestamp);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    d.writeTo(out);
+    metric.writeTo(out);
 
     List<InputRow> rows = parser.parseBatch(ByteBuffer.wrap(out.toByteArray()));
 
@@ -168,9 +168,9 @@ public class OpenCensusProtobufInputRowParserTest
     Timestamp timestamp = Timestamp.newBuilder().setSeconds(dateTime.getMillis() / 1000)
         .setNanos((int) ((dateTime.getMillis() % 1000) * 1000000)).build();
 
-    Metric d = summaryMetric(timestamp);
+    Metric metric = summaryMetric(timestamp);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    d.writeTo(out);
+    metric.writeTo(out);
 
     List<InputRow> rows = parser.parseBatch(ByteBuffer.wrap(out.toByteArray()));
 
@@ -199,9 +199,9 @@ public class OpenCensusProtobufInputRowParserTest
     Timestamp timestamp = Timestamp.newBuilder().setSeconds(dateTime.getMillis() / 1000)
         .setNanos((int) ((dateTime.getMillis() % 1000) * 1000000)).build();
 
-    Metric d = summaryMetric(timestamp);
+    Metric metric = summaryMetric(timestamp);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    d.writeTo(out);
+    metric.writeTo(out);
 
     List<InputRow> rows = parser.parseBatch(ByteBuffer.wrap(out.toByteArray()));
 

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.opencensus.protobuf;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.Int64Value;
@@ -35,6 +36,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.JSONParseSpec;
 import org.apache.druid.data.input.impl.ParseSpec;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
@@ -59,6 +61,8 @@ public class OpenCensusProtobufInputRowParserTest
 
   private ParseSpec parseSpec;
 
+  private ParseSpec parseSpecWithDimensions;
+
   @Before
   public void setUp()
   {
@@ -75,6 +79,20 @@ public class OpenCensusProtobufInputRowParserTest
         ), null
     );
 
+    parseSpecWithDimensions = new JSONParseSpec(
+        new TimestampSpec("timestamp", "millis", null),
+        new DimensionsSpec(ImmutableList.of(
+            new StringDimensionSchema("foo_key"),
+            new StringDimensionSchema("env_key")), null, null),
+        new JSONPathSpec(
+            true,
+            Lists.newArrayList(
+                new JSONPathFieldSpec(JSONPathFieldType.ROOT, "name", ""),
+                new JSONPathFieldSpec(JSONPathFieldType.ROOT, "value", ""),
+                new JSONPathFieldSpec(JSONPathFieldType.ROOT, "foo_key", "")
+            )
+        ), null
+    );
   }
 
 
@@ -136,6 +154,70 @@ public class OpenCensusProtobufInputRowParserTest
     assertDimensionEquals(row, "name", "metric_summary-sum");
     assertDimensionEquals(row, "foo_key", "foo_value");
     Assert.assertEquals(10, row.getMetric("value").doubleValue(), 0.0);
+
+  }
+
+  @Test
+  public void testDimensionsParseWithParseSpecDimensions() throws Exception
+  {
+    //configure parser with desc file
+    OpenCensusProtobufInputRowParser parser = new OpenCensusProtobufInputRowParser(parseSpecWithDimensions);
+
+    DateTime dateTime = new DateTime(2019, 07, 12, 9, 30, ISOChronology.getInstanceUTC());
+
+    Timestamp timestamp = Timestamp.newBuilder().setSeconds(dateTime.getMillis() / 1000)
+        .setNanos((int) ((dateTime.getMillis() % 1000) * 1000000)).build();
+
+    Metric d = summaryMetric(timestamp);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    d.writeTo(out);
+
+    List<InputRow> rows = parser.parseBatch(ByteBuffer.wrap(out.toByteArray()));
+
+    Assert.assertEquals(2, rows.size());
+
+    InputRow row = rows.get(0);
+    Assert.assertEquals(2, row.getDimensions().size());
+    assertDimensionEquals(row, "env_key", "env_val");
+    assertDimensionEquals(row, "foo_key", "foo_value");
+
+    row = rows.get(1);
+    Assert.assertEquals(2, row.getDimensions().size());
+    assertDimensionEquals(row, "env_key", "env_val");
+    assertDimensionEquals(row, "foo_key", "foo_value");
+
+  }
+
+  @Test
+  public void testDimensionsParseWithoutParseSpecDimensions() throws Exception
+  {
+    //configure parser with desc file
+    OpenCensusProtobufInputRowParser parser = new OpenCensusProtobufInputRowParser(parseSpec);
+
+    DateTime dateTime = new DateTime(2019, 07, 12, 9, 30, ISOChronology.getInstanceUTC());
+
+    Timestamp timestamp = Timestamp.newBuilder().setSeconds(dateTime.getMillis() / 1000)
+        .setNanos((int) ((dateTime.getMillis() % 1000) * 1000000)).build();
+
+    Metric d = summaryMetric(timestamp);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    d.writeTo(out);
+
+    List<InputRow> rows = parser.parseBatch(ByteBuffer.wrap(out.toByteArray()));
+
+    Assert.assertEquals(2, rows.size());
+
+    InputRow row = rows.get(0);
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "name", "metric_summary-count");
+    assertDimensionEquals(row, "env_key", "env_val");
+    assertDimensionEquals(row, "foo_key", "foo_value");
+
+    row = rows.get(1);
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "name", "metric_summary-sum");
+    assertDimensionEquals(row, "env_key", "env_val");
+    assertDimensionEquals(row, "foo_key", "foo_value");
 
   }
 


### PR DESCRIPTION
- Adding `Metric.Resource` data to labels.
- Adding `Metric.Resource` keys to `DimensionsSpec`, if not explicitly declared.
- Refactoring `repeated` code out of `switch` statement.

Testing
- Added test cases for both scenarios when with and without declared `DimensionsSpec`.