### PR TITLE
Default resource label prefix to blank - Backward Compatibility

### DIFF
--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
@@ -55,7 +55,7 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
   private static final String DEFAULT_METRIC_DIMENSION = "name";
   private static final String VALUE = "value";
   private static final String TIMESTAMP_COLUMN = "timestamp";
-  private static final String DEFAULT_RESOURCE_PREFIX = "resource.";
+  private static final String DEFAULT_RESOURCE_PREFIX = "";
   private final ParseSpec parseSpec;
   private final List<String> dimensions;
 

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
@@ -322,13 +322,13 @@ public class OpenCensusProtobufInputRowParserTest
     Assert.assertEquals(4, row.getDimensions().size());
     assertDimensionEquals(row, "name", "metric_summary-count");
     assertDimensionEquals(row, "foo_key", "foo_value");
-    assertDimensionEquals(row, "resource.env_key", "env_val");
+    assertDimensionEquals(row, "env_key", "env_val");
 
     row = rows.get(1);
     Assert.assertEquals(4, row.getDimensions().size());
     assertDimensionEquals(row, "name", "metric_summary-sum");
     assertDimensionEquals(row, "foo_key", "foo_value");
-    assertDimensionEquals(row, "resource.env_key", "env_val");
+    assertDimensionEquals(row, "env_key", "env_val");
   }
 
   @Test


### PR DESCRIPTION
As the change is not backward compatible hence default `resource label prefix` to `blank` for deployment.

After deployment make respective changes in `druid ingestion spec` and revert this commit.