### PR TITLE
[backport] fix unsafe concurrent access in StreamAppenderatorDriver (#9943)

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/topn/TopNUnionQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/TopNUnionQueryTest.java
@@ -33,6 +33,7 @@ import org.apache.druid.query.TestQueryRunners;
 import org.apache.druid.query.aggregation.DoubleMaxAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleMinAggregatorFactory;
 import org.apache.druid.segment.TestHelper;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +47,7 @@ import java.util.List;
 import java.util.Map;
 
 @RunWith(Parameterized.class)
-public class TopNUnionQueryTest
+public class TopNUnionQueryTest extends InitializedNullHandlingTest
 {
   private static final Closer RESOURCE_CLOSER = Closer.create();
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
@@ -428,9 +428,9 @@ public abstract class BaseAppenderatorDriver implements Closeable
   }
 
   /**
-   * Returns a stream of {@link SegmentWithState} for the given sequenceNames.
+   * Returns a stream of {@link SegmentIdWithShardSpec} for the given sequenceNames.
    */
-  Stream<SegmentWithState> getSegmentWithStates(Collection<String> sequenceNames)
+  List<SegmentIdWithShardSpec> getSegmentIdsWithShardSpecs(Collection<String> sequenceNames)
   {
     synchronized (segments) {
       return sequenceNames
@@ -438,11 +438,13 @@ public abstract class BaseAppenderatorDriver implements Closeable
           .map(segments::get)
           .filter(Objects::nonNull)
           .flatMap(segmentsForSequence -> segmentsForSequence.intervalToSegmentStates.values().stream())
-          .flatMap(segmentsOfInterval -> segmentsOfInterval.getAllSegments().stream());
+          .flatMap(segmentsOfInterval -> segmentsOfInterval.getAllSegments().stream())
+          .map(SegmentWithState::getSegmentIdentifier)
+          .collect(Collectors.toList());
     }
   }
 
-  Stream<SegmentWithState> getAppendingSegments(Collection<String> sequenceNames)
+  Set<SegmentIdWithShardSpec> getAppendingSegments(Collection<String> sequenceNames)
   {
     synchronized (segments) {
       return sequenceNames
@@ -451,7 +453,9 @@ public abstract class BaseAppenderatorDriver implements Closeable
           .filter(Objects::nonNull)
           .flatMap(segmentsForSequence -> segmentsForSequence.intervalToSegmentStates.values().stream())
           .map(segmentsOfInterval -> segmentsOfInterval.appendingSegment)
-          .filter(Objects::nonNull);
+          .filter(Objects::nonNull)
+          .map(SegmentWithState::getSegmentIdentifier)
+          .collect(Collectors.toSet());
     }
   }
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorDriver.java
@@ -136,9 +136,7 @@ public class BatchAppenderatorDriver extends BaseAppenderatorDriver
       long pushAndClearTimeoutMs
   ) throws InterruptedException, ExecutionException, TimeoutException
   {
-    final Set<SegmentIdWithShardSpec> requestedSegmentIdsForSequences = getAppendingSegments(sequenceNames)
-        .map(SegmentWithState::getSegmentIdentifier)
-        .collect(Collectors.toSet());
+    final Set<SegmentIdWithShardSpec> requestedSegmentIdsForSequences = getAppendingSegments(sequenceNames);
 
     final ListenableFuture<SegmentsAndMetadata> future = ListenableFutures.transformAsync(
         pushInBackground(null, requestedSegmentIdsForSequences, false),

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
@@ -270,9 +270,7 @@ public class StreamAppenderatorDriver extends BaseAppenderatorDriver
       final Collection<String> sequenceNames
   )
   {
-    final List<SegmentIdWithShardSpec> theSegments = getSegmentWithStates(sequenceNames)
-        .map(SegmentWithState::getSegmentIdentifier)
-        .collect(Collectors.toList());
+    final List<SegmentIdWithShardSpec> theSegments = getSegmentIdsWithShardSpecs(sequenceNames);
 
     final ListenableFuture<SegmentsAndMetadata> publishFuture = ListenableFutures.transformAsync(
         // useUniquePath=true prevents inconsistencies in segment data when task failures or replicas leads to a second


### PR DESCRIPTION
during segment publishing we do streaming operations on a collection not
safe for concurrent modification. To guarantee correct results we must
also guard any operations on the stream itself.

This may explain the issue seen in https://github.com/apache/druid/issues/9845
