### PR TITLE
Return appropriate config directory path for indexer process

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -54,6 +54,7 @@ getConfPath() {
     _common) echo $cluster_conf_base/_common ;;
     historical) echo $cluster_conf_base/data/historical ;;
     middleManager) echo $cluster_conf_base/data/middleManager ;;
+    indexer) echo $cluster_conf_base/data/indexer ;;
     coordinator | overlord) echo $cluster_conf_base/master/coordinator-overlord ;;
     broker) echo $cluster_conf_base/query/broker ;;
     router) echo $cluster_conf_base/query/router ;;


### PR DESCRIPTION
Backporting https://github.com/apache/druid/pull/10657 from apache/druid master.

Note:
integration-tests/docker/druid.sh file itself isn't present in our fork yet.