### PR TITLE
Add status/selfDiscovered endpoint to indexer for self discovery of indexer (#10679)

### DIFF
--- a/examples/conf/druid/cluster/data/indexer/jvm.config
+++ b/examples/conf/druid/cluster/data/indexer/jvm.config
@@ -1,0 +1,9 @@
+-server
+-Xms4g
+-Xmx4g
+-XX:MaxDirectMemorySize=4g
+-XX:+ExitOnOutOfMemoryError
+-Duser.timezone=UTC
+-Dfile.encoding=UTF-8
+-Djava.io.tmpdir=var/tmp
+-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager

--- a/examples/conf/druid/cluster/data/indexer/main.config
+++ b/examples/conf/druid/cluster/data/indexer/main.config
@@ -1,0 +1,1 @@
+org.apache.druid.cli.Main server indexer

--- a/examples/conf/druid/cluster/data/indexer/runtime.properties
+++ b/examples/conf/druid/cluster/data/indexer/runtime.properties
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+druid.service=druid/indexer
+druid.plaintextPort=8091
+
+# Number of tasks per indexer
+druid.worker.capacity=4
+
+# Task launch parameters
+druid.indexer.task.baseTaskDir=var/druid/task
+
+# HTTP server threads
+druid.server.http.numThreads=60
+
+# Processing threads and buffers on Indexer
+druid.processing.numMergeBuffers=2
+druid.processing.buffer.sizeBytes=100MiB
+druid.processing.numThreads=4
+
+# Hadoop indexing
+druid.indexer.task.hadoopWorkingPath=var/druid/hadoop-tmp

--- a/services/src/main/java/org/apache/druid/cli/CliIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliIndexer.java
@@ -22,6 +22,7 @@ package org.apache.druid.cli;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
@@ -71,6 +72,7 @@ import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordination.ZkCoordinator;
 import org.apache.druid.server.http.HistoricalResource;
 import org.apache.druid.server.http.SegmentListerResource;
+import org.apache.druid.server.http.SelfDiscoveryResource;
 import org.apache.druid.server.initialization.jetty.CliIndexerServerModule;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.eclipse.jetty.server.Server;
@@ -161,6 +163,9 @@ public class CliIndexer extends ServerRunnable
                     )
                     .build()
             );
+
+            Jerseys.addResource(binder, SelfDiscoveryResource.class);
+            LifecycleModule.registerKey(binder, Key.get(SelfDiscoveryResource.class));
           }
 
           @Provides


### PR DESCRIPTION
Added the status/selfDiscovered endpoint to indexer. Per the api-reference doc, all services support status/selfDiscovered endpoint. So this change would fix that expected behavior.

Also added example config files for indexer process that can be used to spin up the indexer process. 

(cherry picked from commit c2e26d2e1cc2218dbb1b25dc2794787fc43e24fa)