### PR TITLE
Unit tests fail due to missing extend InitializedNullHandlingTest (#10382)

### DIFF
--- a/core/src/test/java/org/apache/druid/data/input/FirehoseFactoryToInputSourceAdaptorTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/FirehoseFactoryToInputSourceAdaptorTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,7 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class FirehoseFactoryToInputSourceAdaptorTest
+public class FirehoseFactoryToInputSourceAdaptorTest extends InitializedNullHandlingTest
 {
   @Test
   public void testUnimplementedInputFormat() throws IOException

--- a/core/src/test/java/org/apache/druid/data/input/impl/CsvInputFormatTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/CsvInputFormatTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.data.input.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.util.Collections;
 
-public class CsvInputFormatTest
+public class CsvInputFormatTest extends InitializedNullHandlingTest
 {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();


### PR DESCRIPTION
backport of #10382

* CsvInputFormatTest should extend InitializedNullHandlingTest

* FirehoseFactoryToInputSourceAdaptorTest should extends InitializedNullHandlingTest