### PR TITLE
Cherry-pick: adding config control for query context 

### DIFF
--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -45,6 +45,8 @@ type Capabilities = 'working-with-sql' | 'working-without-sql' | 'broken';
 export interface ConsoleApplicationProps {
   hideLegacy: boolean;
   exampleManifestsUrl?: string;
+  defaultQueryContext?: Record<string, any>;
+  mandatoryQueryContext?: Record<string, any>;
 }
 
 export interface ConsoleApplicationState {
@@ -246,7 +248,16 @@ export class ConsoleApplication extends React.PureComponent<
   };
 
   private wrappedQueryView = () => {
-    return this.wrapInViewContainer('query', <QueryView initQuery={this.initQuery} />);
+    const { defaultQueryContext, mandatoryQueryContext } = this.props;
+
+    return this.wrapInViewContainer(
+      'query',
+      <QueryView
+        initQuery={this.initQuery}
+        defaultQueryContext={defaultQueryContext}
+        mandatoryQueryContext={mandatoryQueryContext}
+      />,
+    );
   };
 
   private wrappedDatasourcesView = () => {

--- a/web-console/src/entry.ts
+++ b/web-console/src/entry.ts
@@ -37,13 +37,26 @@ const container = document.getElementsByClassName('app-container')[0];
 if (!container) throw new Error('container not found');
 
 interface ConsoleConfig {
+  // A custom title for the page
   title?: string;
   hideLegacy?: boolean;
   baseURL?: string;
+
+  // A custom header name/value to set on every AJAX request
   customHeaderName?: string;
   customHeaderValue?: string;
+
+  // A set of custom headers name/value to set on every AJAX request
   customHeaders?: Record<string, string>;
+
+  // The URL for where to load the example manifest, a JSON document that tells the console where to find all the example datasets
   exampleManifestsUrl?: string;
+
+  // The query context to set if the user does not have one saved in local storage, defaults to {}
+  defaultQueryContext?: Record<string, any>;
+
+  // Extra context properties that will be added to all query requests
+  mandatoryQueryContext?: Record<string, any>;
 }
 
 const consoleConfig: ConsoleConfig = (window as any).consoleConfig;
@@ -66,6 +79,8 @@ ReactDOM.render(
   React.createElement(ConsoleApplication, {
     hideLegacy: Boolean(consoleConfig.hideLegacy),
     exampleManifestsUrl: consoleConfig.exampleManifestsUrl,
+    defaultQueryContext: consoleConfig.defaultQueryContext,
+    mandatoryQueryContext: consoleConfig.mandatoryQueryContext,
   }) as any,
   container,
 );

--- a/web-console/src/views/query-view/query-view.tsx
+++ b/web-console/src/views/query-view/query-view.tsx
@@ -83,6 +83,8 @@ interface QueryWithContext {
 
 export interface QueryViewProps {
   initQuery: string | undefined;
+  defaultQueryContext?: Record<string, any>;
+  mandatoryQueryContext?: Record<string, any>;
 }
 
 export interface QueryViewState {
@@ -184,11 +186,13 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
 
   constructor(props: QueryViewProps, context: any) {
     super(props, context);
+    const { mandatoryQueryContext } = props;
 
     const queryString = props.initQuery || localStorageGet(LocalStorageKeys.QUERY_KEY) || '';
     const parsedQuery = queryString ? parser(queryString) : undefined;
 
-    const queryContext = localStorageGetJson(LocalStorageKeys.QUERY_CONTEXT) || {};
+    const queryContext =
+      localStorageGetJson(LocalStorageKeys.QUERY_CONTEXT) || props.defaultQueryContext || {};
 
     const possibleQueryHistory = localStorageGetJson(LocalStorageKeys.QUERY_HISTORY);
     const queryHistory = Array.isArray(possibleQueryHistory) ? possibleQueryHistory : [];
@@ -262,8 +266,14 @@ export class QueryView extends React.PureComponent<QueryViewProps, QueryViewStat
           };
         }
 
-        if (!isEmptyContext(queryContext)) {
-          jsonQuery.context = Object.assign(jsonQuery.context || {}, queryContext);
+        if (!isEmptyContext(queryContext) || wrapQueryLimit || mandatoryQueryContext) {
+          jsonQuery.context = Object.assign(
+            {},
+            jsonQuery.context || {},
+            queryContext,
+            mandatoryQueryContext || {},
+          );
+          jsonQuery.context.sqlOuterLimit = wrapQueryLimit;
         }
 
         let rawQueryResult: unknown;


### PR DESCRIPTION
* add default and mandetory query contexts

* added config docs

<!-- Thanks for trying to help us make Apache Druid (incubating) be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/incubator-druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
Cherry-pick https://github.com/apache/druid/pull/9499
Edit query context in console-config.js
<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/incubator-druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/incubator-druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
