### PR TITLE
Setting default query lane from druid console.

### DIFF
--- a/web-console/console-config.js
+++ b/web-console/console-config.js
@@ -21,6 +21,7 @@ window.consoleConfig = {
   /* future configs may go here */
   "defaultQueryContext": {
     "priority": -1,
-    "timeout": 30000
+    "timeout": 30000,
+    "lane": "console"
   }
 };


### PR DESCRIPTION
Setting default `lane` in query context for queries made from Druid console.