### PR TITLE
Initializing NullHandling module in TimeSeriesUnionQueryRunnerTest.java.

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeSeriesUnionQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeSeriesUnionQueryRunnerTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.query.UnionQueryRunner;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.segment.TestHelper;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,7 +45,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @RunWith(Parameterized.class)
-public class TimeSeriesUnionQueryRunnerTest
+public class TimeSeriesUnionQueryRunnerTest extends InitializedNullHandlingTest
 {
   private final QueryRunner runner;
   private final boolean descending;


### PR DESCRIPTION
Fixing the following unit test failure
```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.01 s <<< FAILURE! - in org.apache.druid.query.timeseries.TimeSeriesUnionQueryRunnerTest00:44
[ERROR] initializationError(org.apache.druid.query.timeseries.TimeSeriesUnionQueryRunnerTest)  Time elapsed: 0.01 s  <<< ERROR!00:44
java.lang.IllegalStateException: NullHandling module not initialized, call NullHandling.initializeForTests()00:44
	at org.apache.druid.common.config.NullHandling.replaceWithDefault(NullHandling.java:71)00:44
	at org.apache.druid.segment.column.ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnCapabilitiesImpl.java:165)00:44
	at org.apache.druid.segment.incremental.IncrementalIndex$MetricDesc.<init>(IncrementalIndex.java:1102)00:44
	at org.apache.druid.segment.incremental.IncrementalIndex.<init>(IncrementalIndex.java:283)
```