### PR TITLE
Fixing TimeSeriesUnionQueryRunnerTest and giving more heap space for tests.

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -78,7 +78,7 @@ blocks:
               value: extensions-contrib/confluent-extensions
           commands: &run_tests
             - >
-              MAVEN_OPTS="${MAVEN_OPTS} -Xmx800m" ${MVN} test -pl ${MAVEN_PROJECTS}
+              MAVEN_OPTS="${MAVEN_OPTS} -Xmx1g" ${MVN} test -pl ${MAVEN_PROJECTS}
               ${MAVEN_SKIP} -Dremoteresources.skip=true
 
         - name: "Server"

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeSeriesUnionQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeSeriesUnionQueryRunnerTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.query.UnionQueryRunner;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.segment.TestHelper;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,7 +45,7 @@ import java.util.Arrays;
 import java.util.List;
 
 @RunWith(Parameterized.class)
-public class TimeSeriesUnionQueryRunnerTest
+public class TimeSeriesUnionQueryRunnerTest extends InitializedNullHandlingTest
 {
   private final QueryRunner runner;
   private final boolean descending;


### PR DESCRIPTION
Fixing TimeSeriesUnionQueryRunnerTest by extending InitializedNullHandlingTest
Also giving more heap space for test jvm in semaphore config.
