### PR TITLE
Avoid expensive findEntry call in segment metadata query (#10892)

### DIFF
--- a/core/src/test/java/org/apache/druid/data/input/impl/FileIteratingFirehoseTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/FileIteratingFirehoseTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.data.input.impl;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.LineIterator;
+import org.apache.druid.common.config.NullHandlingTest;
 import org.apache.druid.data.input.InputRow;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,7 +42,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @RunWith(Parameterized.class)
-public class FileIteratingFirehoseTest
+public class FileIteratingFirehoseTest extends NullHandlingTest
 {
   @Parameters(name = "{0}, {1}")
   public static Collection<Object[]> constructorFeeder()

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -35,8 +35,11 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.guava.LazySequence;
+import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryCapacityExceededException;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryException;
@@ -105,6 +108,8 @@ public class SqlResourceTest extends CalciteTestBase
   private HttpServletRequest req;
   private ListeningExecutorService executorService;
 
+  private boolean sleep = false;
+
   @BeforeClass
   public static void setUpClass()
   {
@@ -126,7 +131,27 @@ public class SqlResourceTest extends CalciteTestBase
         ManualQueryPrioritizationStrategy.INSTANCE,
         new HiLoQueryLaningStrategy(40),
         new ServerConfig()
-    );
+    )
+    {
+      @Override
+      public <T> Sequence<T> run(Query<?> query, Sequence<T> resultSequence)
+      {
+        return super.run(
+            query,
+            new LazySequence<T>(() -> {
+              if (sleep) {
+                try {
+                  // pretend to be a query that is waiting on results
+                  Thread.sleep(500);
+                }
+                catch (InterruptedException ignored) {
+                }
+              }
+              return resultSequence;
+            })
+        );
+      }
+    };
 
     executorService = MoreExecutors.listeningDecorator(Execs.multiThreaded(8, "test_sql_resource_%s"));
     walker = CalciteTests.createMockWalker(conglomerate, temporaryFolder.newFolder(), scheduler);
@@ -801,6 +826,7 @@ public class SqlResourceTest extends CalciteTestBase
   @Test
   public void testTooManyRequests() throws Exception
   {
+    sleep = true;
     final int numQueries = 3;
 
     List<Future<Pair<QueryException, List<Map<String, Object>>>>> futures = new ArrayList<>(numQueries);


### PR DESCRIPTION
Cherry-picking commits from https://github.com/apache/druid/pull/10892

* Avoid expensive findEntry call in segment metadata query

* other places

* Remove findEntry

* Fix add cost

* Refactor a bit

* Add performance test

* Add comment

* Review comments

* intellij

(cherry picked from commit 489f5b1a03c8c3d35374c9eb6fd140f33c4f3fb1)
