### PR TITLE
Kafka input format changes

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderFormat.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.kafka.common.header.Headers;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+        @JsonSubTypes.Type(name = "string", value = KafkaStringHeaderFormat.class)
+})
+
+public interface KafkaHeaderFormat
+{
+  KafkaHeaderReader createReader(
+            Headers headers,
+            String headerLabelPrefix
+    );
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderReader.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import org.apache.druid.data.input.InputRow;
+import java.io.IOException;
+import java.util.Map;
+
+public interface KafkaHeaderReader
+{
+  Map<String, Object> read() throws IOException;
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderReader.java
@@ -19,10 +19,12 @@
 
 package org.apache.druid.data.input.kafkainput;
 
+import org.apache.druid.java.util.common.Pair;
+
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 
 public interface KafkaHeaderReader
 {
-  Map<String, Object> read() throws IOException;
+  List<Pair<String, Object>> read() throws IOException;
 }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderReader.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.data.input.kafkainput;
 
-import org.apache.druid.data.input.InputRow;
 import java.io.IOException;
 import java.util.Map;
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
@@ -41,11 +41,12 @@ public class KafkaInputFormat implements InputFormat
   private static final String DEFAULT_KEY_COLUMN_PREFIX = "kafka.";
   private static final String DEFAULT_TIMESTAMP_STRING = "timestamp";
   private static final String DEFAULT_KEY_STRING = "key";
+  public static final String DEFAULT_AUTO_TIMESTAMP_STRING = "__kif_auto_timestamp";
 
   // Since KafkaInputFormat blends data from header, key and payload, timestamp spec can be pointing to an attribute within one of these
   // 3 sections. To handle scenarios where there is no timestamp value either in key or payload, we induce an artifical timestamp value
   // to avoid unnecessary parser barf out. Users in such situations can use the inputFormat's kafka record timestamp as its primary timestamp.
-  private final TimestampSpec dummyTimestampSpec = new TimestampSpec("__kif_auto_timestamp", "auto", DateTimes.EPOCH);
+  private final TimestampSpec dummyTimestampSpec = new TimestampSpec(DEFAULT_AUTO_TIMESTAMP_STRING, "auto", DateTimes.EPOCH);
 
   private final KafkaHeaderFormat headerFormat;
   private final InputFormat valueFormat;

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.data.input.InputEntity;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.druid.java.util.common.DateTimes;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.util.Collections;
+import java.util.Objects;
+
+public class KafkaInputFormat implements InputFormat
+{
+  private static final String DEFAULT_HEADER_LABEL_PREFIX = "kafka.header.";
+  private static final String DEFAULT_TIMESTAMP_LABEL_PREFIX = "kafka.";
+  private static final String DEFAULT_KEY_LABEL_PREFIX = "kafka.";
+
+  private final KafkaHeaderFormat headerReader;
+  private final InputFormat valueFormat;
+  private final InputFormat keyFormat;
+  private final String headerLabelPrefix;
+  private final String keyLabelPrefix;
+  private final String recordTimestampLabelPrefix;
+
+  public KafkaInputFormat(
+      @JsonProperty("headerFormat") KafkaHeaderFormat headerReader,
+      @JsonProperty("keyFormat") InputFormat keyFormat,
+      @JsonProperty("valueFormat") InputFormat valueFormat,
+      @JsonProperty("headerLabelPrefix") @Nullable String headerLabelPrefix,
+      @JsonProperty("keyLabelPrefix") @Nullable String keyLabelPrefix,
+      @JsonProperty("recordTimestampLabelPrefix") @Nullable String recordTimestampLabelPrefix
+  )
+  {
+    this.headerReader = Preconditions.checkNotNull(headerReader, "headerFormat");
+    this.keyFormat = Preconditions.checkNotNull(keyFormat, "keyFormat");
+    this.valueFormat = Preconditions.checkNotNull(valueFormat, "valueFormat");
+    this.headerLabelPrefix = headerLabelPrefix != null ? headerLabelPrefix : DEFAULT_HEADER_LABEL_PREFIX;
+    this.keyLabelPrefix = keyLabelPrefix != null ? keyLabelPrefix : DEFAULT_KEY_LABEL_PREFIX;
+    this.recordTimestampLabelPrefix = recordTimestampLabelPrefix != null ? recordTimestampLabelPrefix : DEFAULT_TIMESTAMP_LABEL_PREFIX;
+  }
+
+  @Override
+  public boolean isSplittable()
+  {
+    return false;
+  }
+
+  @Override
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  {
+    KafkaRecordEntity record = (KafkaRecordEntity) source;
+    TimestampSpec dummyTimestampSpec = new TimestampSpec("__kif_auto_timestamp", "auto", DateTimes.of("2021-06-24"));
+    InputRowSchema newInputRowSchema = new InputRowSchema(dummyTimestampSpec, inputRowSchema.getDimensionsSpec(), inputRowSchema.getMetricNames());
+    return new KafkaInputReader(
+            inputRowSchema,
+            record,
+            this.headerReader.createReader(record.getRecord().headers(), this.headerLabelPrefix),
+            (record.getRecord().key() != null) ?
+            this.keyFormat.createReader(
+                    newInputRowSchema,
+                    new ByteEntity(record.getRecord().key()),
+                    temporaryDirectory
+            ) : null,
+            this.valueFormat.createReader(
+                    newInputRowSchema,
+                    source,
+                    temporaryDirectory
+            ),
+            this.keyLabelPrefix,
+            this.recordTimestampLabelPrefix
+    );
+  }
+
+  @JsonProperty
+  public KafkaHeaderFormat getHeaderFormat()
+  {
+    return headerReader;
+  }
+
+  @JsonProperty
+  public InputFormat getValueFormat()
+  {
+    return valueFormat;
+  }
+
+  @JsonProperty
+  public InputFormat getKeyFormat()
+  {
+    return keyFormat;
+  }
+
+  @JsonProperty
+  public String getHeaderLabelPrefix()
+  {
+    return headerLabelPrefix;
+  }
+
+  @JsonProperty
+  public String getKeyLabelPrefix()
+  {
+    return keyLabelPrefix;
+  }
+
+  @JsonProperty
+  public String getRecordTimestampLabelPrefix()
+  {
+    return recordTimestampLabelPrefix;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof KafkaInputFormat)) {
+      return false;
+    }
+    KafkaInputFormat that = (KafkaInputFormat) o;
+    return Objects.equals(headerReader, that.headerReader)
+           && Objects.equals(valueFormat, that.valueFormat)
+           && Objects.equals(keyFormat, that.keyFormat)
+           && Objects.equals(headerLabelPrefix, that.headerLabelPrefix)
+           && Objects.equals(keyLabelPrefix, that.keyLabelPrefix)
+           && Objects.equals(recordTimestampLabelPrefix, that.recordTimestampLabelPrefix);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(headerReader, valueFormat, keyFormat,
+                        headerLabelPrefix, keyLabelPrefix, recordTimestampLabelPrefix);
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
@@ -21,21 +21,17 @@ package org.apache.druid.data.input.kafkainput;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.ByteEntity;
-import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.java.util.common.DateTimes;
-import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.util.Collections;
 import java.util.Objects;
 
 public class KafkaInputFormat implements InputFormat

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.data.input.kafkainput;
 
-import org.apache.druid.java.util.common.logger.Logger;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.druid.data.input.InputEntityReader;
@@ -29,6 +28,7 @@ import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.java.util.common.CloseableIterators;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
@@ -91,11 +91,12 @@ public class KafkaInputReader implements InputEntityReader
               keyRow.getEvent().entrySet().stream().findFirst().get().getValue()
           );
         }
-      } catch (Exception e) {
-        if (e instanceof IOException){
+      }
+      catch (Exception e) {
+        if (e instanceof IOException) {
           log.error(e, "Encountered IOException during key parsing.");
-          throw (IOException)e;
-        } else if (e instanceof  ParseException) {
+          throw (IOException) e;
+        } else if (e instanceof ParseException) {
           log.error(e, "Encountered key parsing exception.");
         } else {
           log.error(e, "Encountered exception during key parsing.");
@@ -139,11 +140,12 @@ public class KafkaInputReader implements InputEntityReader
               event
           ));
         }
-      } catch (Exception e) {
-        if (e instanceof IOException){
+      }
+      catch (Exception e) {
+        if (e instanceof IOException) {
           log.error(e, "Encountered IOException during value parsing.");
-          throw (IOException)e;
-        } else if (e instanceof  ParseException) {
+          throw (IOException) e;
+        } else if (e instanceof ParseException) {
           log.error(e, "Encountered value parsing exception.");
         } else {
           log.error(e, "Encountered exception during value parsing.");
@@ -178,4 +180,3 @@ public class KafkaInputReader implements InputEntityReader
     return read().map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
   }
 }
-

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import org.apache.druid.java.util.common.logger.Logger;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowListPlusRawValues;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.druid.java.util.common.CloseableIterators;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class KafkaInputReader implements InputEntityReader
+{
+  private static final Logger log = new Logger(KafkaInputReader.class);
+  private final InputRowSchema inputRowSchema;
+  private final KafkaRecordEntity record;
+  private final KafkaHeaderReader headerParser;
+  private final InputEntityReader keyParser;
+  private final InputEntityReader payloadParser;
+  private final String keyLabelPrefix;
+  private final String recordTimestampLabelPrefix;
+
+  public KafkaInputReader(
+      InputRowSchema inputRowSchema,
+      KafkaRecordEntity record,
+      KafkaHeaderReader headerParser,
+      InputEntityReader keyParser,
+      InputEntityReader payloadParser,
+      String keyLabelPrefix,
+      String recordTimestampLabelPrefix
+  )
+  {
+    this.inputRowSchema = inputRowSchema;
+    this.record = record;
+    this.headerParser = headerParser;
+    this.keyParser = keyParser;
+    this.payloadParser = payloadParser;
+    this.keyLabelPrefix = keyLabelPrefix;
+    this.recordTimestampLabelPrefix = recordTimestampLabelPrefix;
+  }
+
+  @Override
+  public CloseableIterator<InputRow> read() throws IOException
+  {
+    Map<String, Object> mergeList = new HashMap<>(this.headerParser.read());
+
+    if (this.keyParser != null) {
+      CloseableIterator<InputRow> keyIterator = this.keyParser.read();
+      // Key currently only takes the first row and ignores the rest.
+      if (keyIterator.hasNext()) {
+        MapBasedInputRow keyRow =  (MapBasedInputRow) keyIterator.next();
+        mergeList.put(
+            this.keyLabelPrefix + "key",
+            keyRow.getEvent().entrySet().stream().findFirst().get().getValue()
+        );
+      }
+      keyIterator.close();
+    }
+    // Add kafka record timestamp to the mergelist
+    mergeList.put(this.recordTimestampLabelPrefix + "timestamp", this.record.getRecord().timestamp());
+    //log.warn("LOKI Kafka record :" + new String(this.record.getRecord().value(), StandardCharsets.UTF_8));
+
+    CloseableIterator<InputRow> iterator = this.payloadParser.read();
+    List<InputRow> rows = new ArrayList<>();
+    try {
+      while (iterator.hasNext()) {
+      /* Currently we prefer payload attributes if there is a collision in names.
+          We can change this beahvior in later changes with a config knob. This default
+          behavior lets easy porting of existing inputFormats to the new one without any changes.
+       */
+        MapBasedInputRow row = (MapBasedInputRow) iterator.next();
+        Map<String, Object> event = new HashMap<>(row.getEvent());
+        mergeList.forEach((key, value) -> event.merge(key, value, (v1, v2) -> v1));
+
+        HashSet<String> newDimensions = new HashSet<String>(row.getDimensions());
+        newDimensions.addAll(mergeList.keySet());
+        // Free mergeList
+        mergeList = null;
+        // Remove the dummy timestamp added in KafkaInputFormat
+        newDimensions.remove("__kif_auto_timestamp");
+
+        final List<String> schemaDimensions = this.inputRowSchema.getDimensionsSpec().getDimensionNames();
+        final List<String> dimensions;
+        if (!schemaDimensions.isEmpty()) {
+          dimensions = schemaDimensions;
+        } else {
+          dimensions = Lists.newArrayList(
+              Sets.difference(newDimensions, this.inputRowSchema.getDimensionsSpec().getDimensionExclusions())
+          );
+        }
+        rows.add(new MapBasedInputRow(
+            this.inputRowSchema.getTimestampSpec().extractTimestamp(event),
+            dimensions,
+            event));
+      }
+    } catch (Exception e) {
+      log.error(e, "Encountered exception.");
+      if( e instanceof IOException ) {
+        throw (IOException)e;
+      }
+    } finally {
+      // Free the old row iterators
+        iterator.close();
+    }
+    return CloseableIterators.withEmptyBaggage(rows.iterator());
+  }
+
+  @Override
+  public CloseableIterator<InputRowListPlusRawValues> sample() throws IOException
+  {
+    return read().map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
+  }
+}
+

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
@@ -30,9 +30,9 @@ import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.java.util.common.CloseableIterators;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.ParseException;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,11 +42,14 @@ import java.util.Map;
 public class KafkaInputReader implements InputEntityReader
 {
   private static final Logger log = new Logger(KafkaInputReader.class);
+  private static final String DEFAULT_KEY_STRING = "key";
+  private static final String DEFAULT_TIMESTAMP_STRING = "timestamp";
+
   private final InputRowSchema inputRowSchema;
   private final KafkaRecordEntity record;
   private final KafkaHeaderReader headerParser;
   private final InputEntityReader keyParser;
-  private final InputEntityReader payloadParser;
+  private final InputEntityReader valueParser;
   private final String keyLabelPrefix;
   private final String recordTimestampLabelPrefix;
 
@@ -55,7 +58,7 @@ public class KafkaInputReader implements InputEntityReader
       KafkaRecordEntity record,
       KafkaHeaderReader headerParser,
       InputEntityReader keyParser,
-      InputEntityReader payloadParser,
+      InputEntityReader valueParser,
       String keyLabelPrefix,
       String recordTimestampLabelPrefix
   )
@@ -64,7 +67,7 @@ public class KafkaInputReader implements InputEntityReader
     this.record = record;
     this.headerParser = headerParser;
     this.keyParser = keyParser;
-    this.payloadParser = payloadParser;
+    this.valueParser = valueParser;
     this.keyLabelPrefix = keyLabelPrefix;
     this.recordTimestampLabelPrefix = recordTimestampLabelPrefix;
   }
@@ -72,69 +75,103 @@ public class KafkaInputReader implements InputEntityReader
   @Override
   public CloseableIterator<InputRow> read() throws IOException
   {
-    Map<String, Object> mergeList = new HashMap<>(this.headerParser.read());
-
-    if (this.keyParser != null) {
-      CloseableIterator<InputRow> keyIterator = this.keyParser.read();
-      // Key currently only takes the first row and ignores the rest.
-      if (keyIterator.hasNext()) {
-        MapBasedInputRow keyRow =  (MapBasedInputRow) keyIterator.next();
-        mergeList.put(
-            this.keyLabelPrefix + "key",
-            keyRow.getEvent().entrySet().stream().findFirst().get().getValue()
-        );
-      }
-      keyIterator.close();
-    }
+    Map<String, Object> mergeList = new HashMap<>(headerParser.read());
     // Add kafka record timestamp to the mergelist
-    mergeList.put(this.recordTimestampLabelPrefix + "timestamp", this.record.getRecord().timestamp());
-    //log.warn("LOKI Kafka record :" + new String(this.record.getRecord().value(), StandardCharsets.UTF_8));
+    mergeList.put(recordTimestampLabelPrefix + DEFAULT_TIMESTAMP_STRING, record.getRecord().timestamp());
 
-    CloseableIterator<InputRow> iterator = this.payloadParser.read();
+    // Return type for the key parser should be of type MapBasedInputRow
+    // Parsers returning other types are not compatible currently.
+    if (keyParser != null) {
+      try (CloseableIterator<InputRow> keyIterator = keyParser.read()) {
+        // Key currently only takes the first row and ignores the rest.
+        if (keyIterator.hasNext()) {
+          MapBasedInputRow keyRow = (MapBasedInputRow) keyIterator.next();
+          mergeList.put(
+              keyLabelPrefix + DEFAULT_KEY_STRING,
+              keyRow.getEvent().entrySet().stream().findFirst().get().getValue()
+          );
+        }
+      } catch (Exception e) {
+        if (e instanceof IOException){
+          log.error(e, "Encountered IOException during key parsing.");
+          throw (IOException)e;
+        } else if (e instanceof  ParseException) {
+          log.error(e, "Encountered key parsing exception.");
+        } else {
+          log.error(e, "Encountered exception during key parsing.");
+          throw e;
+        }
+      }
+    }
+
     List<InputRow> rows = new ArrayList<>();
-    try {
-      while (iterator.hasNext()) {
+
+    // Return type for the value parser should be of type MapBasedInputRow
+    // Parsers returning other types are not compatible currently.
+    if (valueParser != null) {
+      try (CloseableIterator<InputRow> iterator = valueParser.read()) {
+        while (iterator.hasNext()) {
       /* Currently we prefer payload attributes if there is a collision in names.
           We can change this beahvior in later changes with a config knob. This default
           behavior lets easy porting of existing inputFormats to the new one without any changes.
        */
-        MapBasedInputRow row = (MapBasedInputRow) iterator.next();
-        Map<String, Object> event = new HashMap<>(row.getEvent());
-        mergeList.forEach((key, value) -> event.merge(key, value, (v1, v2) -> v1));
+          MapBasedInputRow row = (MapBasedInputRow) iterator.next();
+          Map<String, Object> event = new HashMap<>(mergeList);
+          event.putAll(row.getEvent());
 
-        HashSet<String> newDimensions = new HashSet<String>(row.getDimensions());
-        newDimensions.addAll(mergeList.keySet());
-        // Free mergeList
-        mergeList = null;
-        // Remove the dummy timestamp added in KafkaInputFormat
-        newDimensions.remove("__kif_auto_timestamp");
+          HashSet<String> newDimensions = new HashSet<String>(row.getDimensions());
+          newDimensions.addAll(mergeList.keySet());
+          // Remove the dummy timestamp added in KafkaInputFormat
+          newDimensions.remove("__kif_auto_timestamp");
 
-        final List<String> schemaDimensions = this.inputRowSchema.getDimensionsSpec().getDimensionNames();
-        final List<String> dimensions;
-        if (!schemaDimensions.isEmpty()) {
-          dimensions = schemaDimensions;
-        } else {
-          dimensions = Lists.newArrayList(
-              Sets.difference(newDimensions, this.inputRowSchema.getDimensionsSpec().getDimensionExclusions())
-          );
+          final List<String> schemaDimensions = inputRowSchema.getDimensionsSpec().getDimensionNames();
+          final List<String> dimensions;
+          if (!schemaDimensions.isEmpty()) {
+            dimensions = schemaDimensions;
+          } else {
+            dimensions = Lists.newArrayList(
+                Sets.difference(newDimensions, inputRowSchema.getDimensionsSpec().getDimensionExclusions())
+            );
+          }
+          rows.add(new MapBasedInputRow(
+              inputRowSchema.getTimestampSpec().extractTimestamp(event),
+              dimensions,
+              event
+          ));
         }
-        rows.add(new MapBasedInputRow(
-            this.inputRowSchema.getTimestampSpec().extractTimestamp(event),
-            dimensions,
-            event));
+      } catch (Exception e) {
+        if (e instanceof IOException){
+          log.error(e, "Encountered IOException during value parsing.");
+          throw (IOException)e;
+        } else if (e instanceof  ParseException) {
+          log.error(e, "Encountered value parsing exception.");
+        } else {
+          log.error(e, "Encountered exception during value parsing.");
+          throw e;
+        }
       }
-    } catch (Exception e) {
-      log.error(e, "Encountered exception.");
-      if( e instanceof IOException ) {
-        throw (IOException)e;
+    } else {
+      HashSet<String> newDimensions = new HashSet<String>(mergeList.keySet());
+      final List<String> schemaDimensions = inputRowSchema.getDimensionsSpec().getDimensionNames();
+      final List<String> dimensions;
+      if (!schemaDimensions.isEmpty()) {
+        dimensions = schemaDimensions;
+      } else {
+        dimensions = Lists.newArrayList(
+            Sets.difference(newDimensions, inputRowSchema.getDimensionsSpec().getDimensionExclusions())
+        );
       }
-    } finally {
-      // Free the old row iterators
-        iterator.close();
+      rows.add(new MapBasedInputRow(
+          inputRowSchema.getTimestampSpec().extractTimestamp(mergeList),
+          dimensions,
+          mergeList
+      ));
     }
+
     return CloseableIterators.withEmptyBaggage(rows.iterator());
   }
 
+  // This API is not implemented yet!
   @Override
   public CloseableIterator<InputRowListPlusRawValues> sample() throws IOException
   {

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormat.java
@@ -24,25 +24,27 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.kafka.common.header.Headers;
 
 import javax.annotation.Nullable;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 public class KafkaStringHeaderFormat implements KafkaHeaderFormat
 {
   private static final Logger log = new Logger(KafkaStringHeaderFormat.class);
-  private static final String DEFAULT_STRING_ENCODING = "UTF8";
-  private final String encoding;
+  private static final Charset DEFAULT_STRING_ENCODING = StandardCharsets.UTF_8;
+  private final Charset encoding;
 
   public KafkaStringHeaderFormat(
       @JsonProperty("encoding") @Nullable String encoding
   )
   {
-    this.encoding = (encoding != null) ? encoding : DEFAULT_STRING_ENCODING;
+    this.encoding = (encoding != null) ? Charset.forName(encoding) : DEFAULT_STRING_ENCODING;
   }
 
   @JsonProperty
   public String getEncoding()
   {
-    return encoding;
+    return encoding.displayName();
   }
 
   @Override

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormat.java
@@ -20,7 +20,6 @@
 package org.apache.druid.data.input.kafkainput;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.kafka.common.header.Headers;
 
 import javax.annotation.Nullable;
@@ -30,21 +29,19 @@ import java.util.Objects;
 
 public class KafkaStringHeaderFormat implements KafkaHeaderFormat
 {
-  private static final Logger log = new Logger(KafkaStringHeaderFormat.class);
-  private static final Charset DEFAULT_STRING_ENCODING = StandardCharsets.UTF_8;
   private final Charset encoding;
 
   public KafkaStringHeaderFormat(
       @JsonProperty("encoding") @Nullable String encoding
   )
   {
-    this.encoding = (encoding != null) ? Charset.forName(encoding) : DEFAULT_STRING_ENCODING;
+    this.encoding = (encoding != null) ? Charset.forName(encoding) : StandardCharsets.UTF_8;
   }
 
   @JsonProperty
   public String getEncoding()
   {
-    return encoding.displayName();
+    return encoding.name();
   }
 
   @Override
@@ -55,8 +52,8 @@ public class KafkaStringHeaderFormat implements KafkaHeaderFormat
   {
     return new KafkaStringHeaderReader(
         headers,
-        this.encoding,
-        headerLabelPrefix
+        headerLabelPrefix,
+        encoding
     );
   }
 

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormat.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.kafka.common.header.Headers;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class KafkaStringHeaderFormat implements KafkaHeaderFormat
+{
+  private static final Logger log = new Logger(KafkaStringHeaderFormat.class);
+  private static final String DEFAULT_STRING_ENCODING = "UTF8";
+  private final String encoding;
+
+  public KafkaStringHeaderFormat(
+      @JsonProperty("encoding") @Nullable String encoding
+  )
+  {
+    this.encoding = (encoding != null) ? encoding : DEFAULT_STRING_ENCODING;
+  }
+
+  @JsonProperty
+  public String getEncoding()
+  {
+    return encoding;
+  }
+
+  @Override
+  public KafkaHeaderReader createReader(
+      Headers headers,
+      String headerLabelPrefix
+  )
+  {
+    return new KafkaStringHeaderReader(
+        headers,
+        this.encoding,
+        headerLabelPrefix
+    );
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof KafkaStringHeaderFormat)) {
+      return false;
+    }
+    KafkaStringHeaderFormat that = (KafkaStringHeaderFormat) o;
+    return Objects.equals(encoding, that.encoding);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(encoding);
+  }
+
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderReader.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class KafkaStringHeaderReader implements KafkaHeaderReader
+{
+  private static final Logger log = new Logger(KafkaStringHeaderReader.class);
+  private final Headers headers;
+  private final String headerLabelPrefix;
+  private final String encoding;
+
+  public KafkaStringHeaderReader(Headers headers,
+                                 String encoding,
+                                 String headerLabelPrefix)
+  {
+    this.headers = headers;
+    this.encoding = encoding;
+    this.headerLabelPrefix = headerLabelPrefix;
+  }
+
+  @Override
+  public Map<String, Object> read() throws IOException
+  {
+    Map<String, Object> events = new HashMap<>();
+    for (Header hdr : headers) {
+      String s = new String(hdr.value(), this.encoding);
+      String newKey = this.headerLabelPrefix + hdr.key();
+      events.put(newKey, s);
+    }
+    return events;
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderReader.java
@@ -19,14 +19,15 @@
 
 package org.apache.druid.data.input.kafkainput;
 
+import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class KafkaStringHeaderReader implements KafkaHeaderReader
 {
@@ -36,22 +37,22 @@ public class KafkaStringHeaderReader implements KafkaHeaderReader
   private final Charset encoding;
 
   public KafkaStringHeaderReader(Headers headers,
-                                 Charset encoding,
-                                 String headerLabelPrefix)
+                                 String headerLabelPrefix,
+                                 Charset encoding)
   {
     this.headers = headers;
-    this.encoding = encoding;
     this.headerLabelPrefix = headerLabelPrefix;
+    this.encoding = encoding;
   }
 
   @Override
-  public Map<String, Object> read() throws IOException
+  public List<Pair<String, Object>> read() throws IOException
   {
-    Map<String, Object> events = new HashMap<>();
+    List<Pair<String, Object>> events = new ArrayList<>();
     for (Header hdr : headers) {
       String s = new String(hdr.value(), this.encoding);
       String newKey = this.headerLabelPrefix + hdr.key();
-      events.put(newKey, s);
+      events.add(Pair.of(newKey, s));
     }
     return events;
   }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderReader.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,10 +33,10 @@ public class KafkaStringHeaderReader implements KafkaHeaderReader
   private static final Logger log = new Logger(KafkaStringHeaderReader.class);
   private final Headers headers;
   private final String headerLabelPrefix;
-  private final String encoding;
+  private final Charset encoding;
 
   public KafkaStringHeaderReader(Headers headers,
-                                 String encoding,
+                                 Charset encoding,
                                  String headerLabelPrefix)
   {
     this.headers = headers;

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
@@ -51,7 +51,7 @@ public class KafkaIndexTaskModule implements DruidModule
                 new NamedType(KafkaSupervisorTuningConfig.class, "kafka"),
                 new NamedType(KafkaSupervisorSpec.class, "kafka"),
                 new NamedType(KafkaSamplerSpec.class, "kafka"),
-                new NamedType(KafkaInputFormat.class, "kafka-input")
+                new NamedType(KafkaInputFormat.class, "kafka")
             )
     );
   }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.TypeLiteral;
+import org.apache.druid.data.input.kafkainput.KafkaInputFormat;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorSpec;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTuningConfig;
@@ -49,7 +50,8 @@ public class KafkaIndexTaskModule implements DruidModule
                 new NamedType(KafkaIndexTaskTuningConfig.class, "KafkaTuningConfig"),
                 new NamedType(KafkaSupervisorTuningConfig.class, "kafka"),
                 new NamedType(KafkaSupervisorSpec.class, "kafka"),
-                new NamedType(KafkaSamplerSpec.class, "kafka")
+                new NamedType(KafkaSamplerSpec.class, "kafka"),
+                new NamedType(KafkaInputFormat.class, "kafka-input")
             )
     );
   }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -236,15 +236,15 @@ public class KafkaInputFormatTest
   @Test
   public void testTimestampFromHeader() throws IOException
   {
-    Iterable<Header> SAMPLE_HEADERS_WITH_TS = Iterables.unmodifiableIterable(
+    Iterable<Header> sample_header_with_ts = Iterables.unmodifiableIterable(
         Iterables.concat(
             SAMPLE_HEADERS,
             ImmutableList.of(new Header() {
               @Override
               public String key()
-      {
-        return "headerTs";
-      }
+              {
+                return "headerTs";
+              }
               @Override
               public byte[] value()
               {
@@ -268,7 +268,7 @@ public class KafkaInputFormatTest
         + "    }\n"
         + "}");
 
-    Headers headers = new RecordHeaders(SAMPLE_HEADERS_WITH_TS);
+    Headers headers = new RecordHeaders(sample_header_with_ts);
     inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
         "sample", 0, 0, timestamp,
         null, null, 0, 0,

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.JsonInputFormat;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+public class KafkaInputFormatTest
+{
+  private KafkaRecordEntity inputEntity;
+  private long timestamp = DateTimes.of("2021-06-24").getMillis();
+  private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(new Header() {
+      @Override
+      public String key()
+      {
+        return "encoding";
+      }
+      @Override
+      public byte[] value()
+      {
+        return "application/json".getBytes(StandardCharsets.UTF_8);
+      }
+    },
+      new Header() {
+      @Override
+      public String key()
+      {
+        return "kafkapkc";
+      }
+      @Override
+      public byte[] value()
+      {
+        return "pkc-bar".getBytes(StandardCharsets.UTF_8);
+      }
+    });
+  private KafkaInputFormat format;
+
+  @Before
+  public void setUp()
+  {
+    format = new KafkaInputFormat(
+        new KafkaStringHeaderFormat(null),
+        // Key Format
+        new JsonInputFormat(
+            new JSONPathSpec(true, ImmutableList.of()),
+            null, null, false //make sure JsonReader is used
+        ),
+        // Value Format
+        new JsonInputFormat(
+            new JSONPathSpec(
+                true,
+                ImmutableList.of(
+                    new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz", "baz"),
+                    new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz2", "baz2"),
+                    new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
+                    new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
+                    new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
+                    new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                )
+            ),
+            null, null, false //make sure JsonReader is used
+        ),
+        "kafka.newheader.", "kafka.newkey.", "kafka.newts."
+    );
+  }
+
+  @Test
+  public void testWithHeaderKeyAndValue() throws IOException
+  {
+    final byte[] key = StringUtils.toUtf8(
+        "{\n"
+        + "    \"key\": \"sampleKey\"\n"
+        + "}");
+
+    final byte[] payload = StringUtils.toUtf8(
+        "{\n"
+        + "    \"timestamp\": \"2021-06-24\",\n"
+        + "    \"bar\": null,\n"
+        + "    \"foo\": \"x\",\n"
+        + "    \"baz\": 4,\n"
+        + "    \"o\": {\n"
+        + "        \"mg\": 1\n"
+        + "    }\n"
+        + "}");
+
+    Headers headers = new RecordHeaders(SAMPLE_HEADERS);
+    inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
+        "sample", 0, 0, timestamp,
+        null, null, 0, 0,
+        key, payload, headers));
+
+    final InputEntityReader reader = format.createReader(
+        new InputRowSchema(
+            new TimestampSpec("timestamp", "iso", null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
+                "bar", "foo",
+                "kafka.newheader.encoding",
+                "kafka.newheader.kafkapkc",
+                "kafka.newts.timestamp"
+            ))),
+            Collections.emptyList()
+        ),
+        inputEntity,
+        null
+    );
+
+    final int numExpectedIterations = 1;
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      int numActualIterations = 0;
+      while (iterator.hasNext()) {
+
+        final InputRow row = iterator.next();
+
+        // Payload verifications
+        Assert.assertEquals(DateTimes.of("2021-06-24"), row.getTimestamp());
+        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+
+        // Header verification
+        Assert.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
+        Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
+        Assert.assertEquals(String.valueOf(DateTimes.of("2021-06-24").getMillis()),
+                            Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp")));
+
+        // Key verification
+        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+
+        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+
+        numActualIterations++;
+      }
+
+      Assert.assertEquals(numExpectedIterations, numActualIterations);
+    }
+  }
+
+  @Test
+  public void testWithOutKey() throws IOException
+  {
+    final byte[] payload = StringUtils.toUtf8(
+        "{\n"
+        + "    \"timestamp\": \"2021-06-24\",\n"
+        + "    \"bar\": null,\n"
+        + "    \"foo\": \"x\",\n"
+        + "    \"baz\": 4,\n"
+        + "    \"o\": {\n"
+        + "        \"mg\": 1\n"
+        + "    }\n"
+        + "}");
+
+    Headers headers = new RecordHeaders(SAMPLE_HEADERS);
+    inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
+        "sample", 0, 0, timestamp,
+        null, null, 0, 0,
+        null, payload, headers));
+
+    final InputEntityReader reader = format.createReader(
+        new InputRowSchema(
+            new TimestampSpec("timestamp", "iso", null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
+                "bar", "foo",
+                "kafka.newheader.encoding",
+                "kafka.newheader.kafkapkc",
+                "kafka.newts.timestamp"
+            ))),
+            Collections.emptyList()
+        ),
+        inputEntity,
+        null
+    );
+
+    final int numExpectedIterations = 1;
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      int numActualIterations = 0;
+      while (iterator.hasNext()) {
+
+        final InputRow row = iterator.next();
+
+        // Key verification
+        Assert.assertTrue(row.getDimension("kafka.newkey.key").isEmpty());
+        numActualIterations++;
+      }
+
+      Assert.assertEquals(numExpectedIterations, numActualIterations);
+    }
+
+  }
+
+  @Test
+  public void testTimestampFromHeader() throws IOException
+  {
+    Iterable<Header> SAMPLE_HEADERS_WITH_TS = Iterables.unmodifiableIterable(
+        Iterables.concat(
+            SAMPLE_HEADERS,
+            ImmutableList.of(new Header() {
+              @Override
+              public String key()
+      {
+        return "headerTs";
+      }
+              @Override
+              public byte[] value()
+              {
+                return "2021-06-24".getBytes(StandardCharsets.UTF_8);
+              }
+            }
+    )));
+    final byte[] key = StringUtils.toUtf8(
+        "{\n"
+        + "    \"key\": \"sampleKey\"\n"
+        + "}");
+
+    final byte[] payload = StringUtils.toUtf8(
+        "{\n"
+        + "    \"timestamp\": \"2021-06-24\",\n"
+        + "    \"bar\": null,\n"
+        + "    \"foo\": \"x\",\n"
+        + "    \"baz\": 4,\n"
+        + "    \"o\": {\n"
+        + "        \"mg\": 1\n"
+        + "    }\n"
+        + "}");
+
+    Headers headers = new RecordHeaders(SAMPLE_HEADERS_WITH_TS);
+    inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
+        "sample", 0, 0, timestamp,
+        null, null, 0, 0,
+        key, payload, headers));
+
+    final InputEntityReader reader = format.createReader(
+        new InputRowSchema(
+            new TimestampSpec("kafka.newheader.headerTs", "iso", null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
+                "bar", "foo",
+                "kafka.newheader.encoding",
+                "kafka.newheader.kafkapkc"
+            ))),
+            Collections.emptyList()
+        ),
+        inputEntity,
+        null
+    );
+
+    final int numExpectedIterations = 1;
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      int numActualIterations = 0;
+      while (iterator.hasNext()) {
+
+        final InputRow row = iterator.next();
+        final MapBasedInputRow mrow = (MapBasedInputRow) row;
+        // Payload verifications
+        Assert.assertEquals(DateTimes.of("2021-06-24"), row.getTimestamp());
+        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+
+        // Header verification
+        Assert.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
+        Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
+        Assert.assertEquals(String.valueOf(DateTimes.of("2021-06-24").getMillis()),
+                            Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp")));
+        Assert.assertEquals("2021-06-24",
+                            Iterables.getOnlyElement(row.getDimension("kafka.newheader.headerTs")));
+        Assert.assertEquals("2021-06-24",
+                            Iterables.getOnlyElement(row.getDimension("timestamp")));
+
+        // Key verification
+        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+
+        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        numActualIterations++;
+      }
+
+      Assert.assertEquals(numExpectedIterations, numActualIterations);
+    }
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
@@ -31,38 +31,44 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 
 public class KafkaStringHeaderFormatTest
 {
-  private KafkaRecordEntity inputEntity;
-  private long timestamp = DateTimes.of("2021-06-24T00:00:00.000Z").getMillis();
-  private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(new Header() {
-      @Override
-      public String key()
+  private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(
+      new Header()
       {
-        return "encoding";
-      }
-      @Override
-      public byte[] value()
+        @Override
+        public String key()
+        {
+          return "encoding";
+        }
+
+        @Override
+        public byte[] value()
+        {
+          return "application/json".getBytes(StandardCharsets.UTF_8);
+        }
+      },
+      new Header()
       {
-        return "application/json".getBytes(StandardCharsets.UTF_8);
-      }
-    },
-      new Header() {
         @Override
         public String key()
         {
           return "kafkapkc";
         }
+
         @Override
         public byte[] value()
         {
           return "pkc-bar".getBytes(StandardCharsets.UTF_8);
         }
-      });
+      }
+  );
+  private KafkaRecordEntity inputEntity;
+  private long timestamp = DateTimes.of("2021-06-24T00:00:00.000Z").getMillis();
 
   @Test
   public void testDefaultHeaderFormat() throws IOException
@@ -73,14 +79,17 @@ public class KafkaStringHeaderFormatTest
     inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
         "sample", 0, 0, timestamp,
         null, null, 0, 0,
-        null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers));
-    Map<String, Object> expectedResults = new HashMap<String, Object>() {{
-        put("test.kafka.header.encoding","application/json");
-        put("test.kafka.header.kafkapkc","pkc-bar");
-    }};
+        null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers
+    ));
+    Map<String, Object> expectedResults = new HashMap<String, Object>() {
+      {
+        put("test.kafka.header.encoding", "application/json");
+        put("test.kafka.header.kafkapkc", "pkc-bar");
+      }
+    };
 
     KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat(null);
-    KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(),headerLabelPrefix);
+    KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(), headerLabelPrefix);
     Assert.assertEquals(expectedResults, headerParser.read());
   }
 
@@ -88,30 +97,35 @@ public class KafkaStringHeaderFormatTest
   public void testASCIIHeaderFormat() throws IOException
   {
     Iterable<Header> header = ImmutableList.of(
-        new Header() {
+        new Header()
+        {
           @Override
           public String key()
           {
             return "encoding";
           }
+
           @Override
           public byte[] value()
           {
             return "application/json".getBytes(StandardCharsets.US_ASCII);
           }
         },
-        new Header() {
+        new Header()
+        {
           @Override
           public String key()
           {
             return "kafkapkc";
           }
+
           @Override
           public byte[] value()
           {
             return "pkc-bar".getBytes(StandardCharsets.US_ASCII);
           }
-        });
+        }
+    );
 
     String headerLabelPrefix = "test.kafka.header.";
     String timestampLablePrefix = "test.kafka.newts.";
@@ -119,14 +133,17 @@ public class KafkaStringHeaderFormatTest
     inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
         "sample", 0, 0, timestamp,
         null, null, 0, 0,
-        null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers));
-    Map<String, Object> expectedResults = new HashMap<String, Object>() {{
-      put("test.kafka.header.encoding","application/json");
-      put("test.kafka.header.kafkapkc","pkc-bar");
-    }};
+        null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers
+    ));
+    Map<String, Object> expectedResults = new HashMap<String, Object>() {
+      {
+        put("test.kafka.header.encoding", "application/json");
+        put("test.kafka.header.kafkapkc", "pkc-bar");
+      }
+    };
 
     KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat("US-ASCII");
-    KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(),headerLabelPrefix);
+    KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(), headerLabelPrefix);
     Map<String, Object> row = headerParser.read();
     Assert.assertEquals(expectedResults, row);
   }
@@ -135,30 +152,35 @@ public class KafkaStringHeaderFormatTest
   public void testIllegalHeaderCharacter() throws IOException
   {
     Iterable<Header> header = ImmutableList.of(
-        new Header() {
+        new Header()
+        {
           @Override
           public String key()
           {
             return "encoding";
           }
+
           @Override
           public byte[] value()
           {
             return "€pplic€tion/json".getBytes(StandardCharsets.US_ASCII);
           }
         },
-        new Header() {
+        new Header()
+        {
           @Override
           public String key()
           {
             return "kafkapkc";
           }
+
           @Override
           public byte[] value()
           {
             return "pkc-bar".getBytes(StandardCharsets.US_ASCII);
           }
-        });
+        }
+    );
 
     String headerLabelPrefix = "test.kafka.header.";
     String timestampLablePrefix = "test.kafka.newts.";
@@ -166,14 +188,17 @@ public class KafkaStringHeaderFormatTest
     inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
         "sample", 0, 0, timestamp,
         null, null, 0, 0,
-        null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers));
-    Map<String, Object> expectedResults = new HashMap<String, Object>() {{
-      put("test.kafka.header.encoding","?pplic?tion/json");
-      put("test.kafka.header.kafkapkc","pkc-bar");
-    }};
+        null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers
+    ));
+    Map<String, Object> expectedResults = new HashMap<String, Object>() {
+      {
+        put("test.kafka.header.encoding", "?pplic?tion/json");
+        put("test.kafka.header.kafkapkc", "pkc-bar");
+      }
+    };
 
     KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat("US-ASCII");
-    KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(),headerLabelPrefix);
+    KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(), headerLabelPrefix);
     Map<String, Object> row = headerParser.read();
     Assert.assertEquals(expectedResults, row);
   }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.HashMap;
+
+
+public class KafkaStringHeaderFormatTest
+{
+  private KafkaRecordEntity inputEntity;
+  private long timestamp = DateTimes.of("2021-06-24T00:00:00.000Z").getMillis();
+  private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(new Header() {
+      @Override
+      public String key()
+      {
+        return "encoding";
+      }
+      @Override
+      public byte[] value()
+      {
+        return "application/json".getBytes(StandardCharsets.UTF_8);
+      }
+    },
+      new Header() {
+        @Override
+        public String key()
+        {
+          return "kafkapkc";
+        }
+        @Override
+        public byte[] value()
+        {
+          return "pkc-bar".getBytes(StandardCharsets.UTF_8);
+        }
+      });
+
+  @Test
+  public void testDefaultHeaderFormat() throws IOException
+  {
+    String headerLabelPrefix = "test.kafka.header.";
+    String timestampLablePrefix = "test.kafka.newts.";
+    Headers headers = new RecordHeaders(SAMPLE_HEADERS);
+    inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
+        "sample", 0, 0, timestamp,
+        null, null, 0, 0,
+        null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers));
+    Map<String, Object> expectedResults = new HashMap<String, Object>() {{
+        put("test.kafka.header.encoding","application/json");
+        put("test.kafka.header.kafkapkc","pkc-bar");
+    }};
+
+    KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat(null);
+    KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(),headerLabelPrefix);
+    Assert.assertEquals(expectedResults, headerParser.read());
+  }
+
+  @Test
+  public void testASCIIHeaderFormat() throws IOException
+  {
+    Iterable<Header> header = ImmutableList.of(
+        new Header() {
+          @Override
+          public String key()
+          {
+            return "encoding";
+          }
+          @Override
+          public byte[] value()
+          {
+            return "application/json".getBytes(StandardCharsets.US_ASCII);
+          }
+        },
+        new Header() {
+          @Override
+          public String key()
+          {
+            return "kafkapkc";
+          }
+          @Override
+          public byte[] value()
+          {
+            return "pkc-bar".getBytes(StandardCharsets.US_ASCII);
+          }
+        });
+
+    String headerLabelPrefix = "test.kafka.header.";
+    String timestampLablePrefix = "test.kafka.newts.";
+    Headers headers = new RecordHeaders(header);
+    inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
+        "sample", 0, 0, timestamp,
+        null, null, 0, 0,
+        null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers));
+    Map<String, Object> expectedResults = new HashMap<String, Object>() {{
+      put("test.kafka.header.encoding","application/json");
+      put("test.kafka.header.kafkapkc","pkc-bar");
+    }};
+
+    KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat("US-ASCII");
+    KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(),headerLabelPrefix);
+    Map<String, Object> row = headerParser.read();
+    Assert.assertEquals(expectedResults, row);
+  }
+}
+

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.data.input.kafkainput;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Pair;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -31,8 +32,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
 
 
 public class KafkaStringHeaderFormatTest
@@ -74,19 +75,16 @@ public class KafkaStringHeaderFormatTest
   public void testDefaultHeaderFormat() throws IOException
   {
     String headerLabelPrefix = "test.kafka.header.";
-    String timestampLablePrefix = "test.kafka.newts.";
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
     inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
         "sample", 0, 0, timestamp,
         null, null, 0, 0,
         null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers
     ));
-    Map<String, Object> expectedResults = new HashMap<String, Object>() {
-      {
-        put("test.kafka.header.encoding", "application/json");
-        put("test.kafka.header.kafkapkc", "pkc-bar");
-      }
-    };
+    List<Pair<String, Object>> expectedResults = Arrays.asList(
+        Pair.of("test.kafka.header.encoding", "application/json"),
+        Pair.of("test.kafka.header.kafkapkc", "pkc-bar")
+    );
 
     KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat(null);
     KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(), headerLabelPrefix);
@@ -128,24 +126,21 @@ public class KafkaStringHeaderFormatTest
     );
 
     String headerLabelPrefix = "test.kafka.header.";
-    String timestampLablePrefix = "test.kafka.newts.";
     Headers headers = new RecordHeaders(header);
     inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
         "sample", 0, 0, timestamp,
         null, null, 0, 0,
         null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers
     ));
-    Map<String, Object> expectedResults = new HashMap<String, Object>() {
-      {
-        put("test.kafka.header.encoding", "application/json");
-        put("test.kafka.header.kafkapkc", "pkc-bar");
-      }
-    };
+    List<Pair<String, Object>> expectedResults = Arrays.asList(
+        Pair.of("test.kafka.header.encoding", "application/json"),
+        Pair.of("test.kafka.header.kafkapkc", "pkc-bar")
+    );
 
     KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat("US-ASCII");
     KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(), headerLabelPrefix);
-    Map<String, Object> row = headerParser.read();
-    Assert.assertEquals(expectedResults, row);
+    List<Pair<String, Object>> rows = headerParser.read();
+    Assert.assertEquals(expectedResults, rows);
   }
 
   @Test
@@ -183,24 +178,21 @@ public class KafkaStringHeaderFormatTest
     );
 
     String headerLabelPrefix = "test.kafka.header.";
-    String timestampLablePrefix = "test.kafka.newts.";
     Headers headers = new RecordHeaders(header);
     inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
         "sample", 0, 0, timestamp,
         null, null, 0, 0,
         null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers
     ));
-    Map<String, Object> expectedResults = new HashMap<String, Object>() {
-      {
-        put("test.kafka.header.encoding", "?pplic?tion/json");
-        put("test.kafka.header.kafkapkc", "pkc-bar");
-      }
-    };
+    List<Pair<String, Object>> expectedResults = Arrays.asList(
+        Pair.of("test.kafka.header.encoding", "?pplic?tion/json"),
+        Pair.of("test.kafka.header.kafkapkc", "pkc-bar")
+    );
 
     KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat("US-ASCII");
     KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(), headerLabelPrefix);
-    Map<String, Object> row = headerParser.read();
-    Assert.assertEquals(expectedResults, row);
+    List<Pair<String, Object>> rows = headerParser.read();
+    Assert.assertEquals(expectedResults, rows);
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Kafka input format initial code review for lab testing.

Tested it on local setup 
1. On metrics and storage topics briefly from sandbox clusters
2. Throughput testing for 10 min interval from sandbox

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
