### PR TITLE
Kafka input format changes

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderFormat.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.kafka.common.header.Headers;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+        @JsonSubTypes.Type(name = "string", value = KafkaStringHeaderFormat.class)
+})
+
+public interface KafkaHeaderFormat
+{
+  KafkaHeaderReader createReader(
+            Headers headers,
+            long timestamp,
+            String headerLabelPrefix,
+            String recordTimestampLabelPrefix
+    );
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaHeaderReader.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import org.apache.druid.data.input.InputRow;
+import java.io.IOException;
+
+public interface KafkaHeaderReader
+{
+  InputRow read() throws IOException;
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowListPlusRawValues;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.java.util.common.CloseableIterators;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class KafkaInputReader implements InputEntityReader
+{
+  private final DimensionsSpec dimensionsSpec;
+  private final KafkaHeaderReader headerParser;
+  private final InputEntityReader keyParser;
+  private final InputEntityReader payloadParser;
+  private final String keyLabelPrefix;
+
+  public KafkaInputReader(
+      DimensionsSpec dimensionsSpec,
+      KafkaHeaderReader headerParser,
+      InputEntityReader keyParser,
+      InputEntityReader payloadParser,
+      String keyLabelPrefix
+  )
+  {
+    this.dimensionsSpec = dimensionsSpec;
+    this.headerParser = headerParser;
+    this.keyParser = keyParser;
+    this.payloadParser = payloadParser;
+    this.keyLabelPrefix = keyLabelPrefix;
+  }
+
+  @Override
+  public CloseableIterator<InputRow> read() throws IOException
+  {
+    MapBasedInputRow keyRow = null;
+    CloseableIterator<InputRow> keyIterator = null;
+    MapBasedInputRow headerRow = (MapBasedInputRow) this.headerParser.read();
+
+    if (this.keyParser != null) {
+      keyIterator = this.keyParser.read();
+      // Key currently only takes the first row and ignores the rest.
+      keyRow = keyIterator.hasNext() ? (MapBasedInputRow) keyIterator.next() : null;
+    }
+
+    CloseableIterator<InputRow> iterator = this.payloadParser.read();
+    List<InputRow> rows = new ArrayList<>();
+    while (iterator.hasNext()) {
+      /* Currently we prefer payload attributes if there is a collision in names.
+          We can change this beahvior in later changes with a config knob. This default
+          behavior lets easy porting of existing inputFormats to the new one without any changes.
+       */
+      MapBasedInputRow row = (MapBasedInputRow) iterator.next();
+      Map<String, Object> event = new HashMap<>(row.getEvent());
+      final Map<String, Object> map2 = headerRow.getEvent();
+      map2.forEach((key, value) -> event.merge(key, value, (v1, v2) -> v1));
+
+      HashSet<String> newDimensions = new HashSet<String>(row.getDimensions());
+      newDimensions.addAll(headerRow.getDimensions());
+
+      // Check if kafka key name is not present in the final list
+      if (keyRow != null && event.get(this.keyLabelPrefix + "key") == null) {
+        event.put(
+                this.keyLabelPrefix + "key",
+                keyRow.getEvent().entrySet().stream().findFirst().get().getValue()
+        );
+        newDimensions.add(this.keyLabelPrefix + "key");
+      }
+
+      final List<String> schemaDimensions = dimensionsSpec.getDimensionNames();
+      final List<String> dimensions;
+      if (!schemaDimensions.isEmpty()) {
+        dimensions = schemaDimensions;
+      } else {
+        dimensions = Lists.newArrayList(
+                Sets.difference(newDimensions, dimensionsSpec.getDimensionExclusions())
+        );
+      }
+      rows.add(new MapBasedInputRow(row.getTimestamp(), dimensions, event));
+    }
+    // Free the old row iterators
+    if (keyIterator != null) {
+      keyIterator.close();
+    }
+    iterator.close();
+    return CloseableIterators.withEmptyBaggage(rows.iterator());
+  }
+
+  @Override
+  public CloseableIterator<InputRowListPlusRawValues> sample() throws IOException
+  {
+    return read().map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
+  }
+}
+

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormat.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.kafka.common.header.Headers;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class KafkaStringHeaderFormat implements KafkaHeaderFormat
+{
+  private static final Logger log = new Logger(KafkaStringHeaderFormat.class);
+  private static final String DEFAULT_STRING_ENCODING = "UTF8";
+  private final String encoding;
+
+    public KafkaStringHeaderFormat(
+            @JsonProperty("encoding") @Nullable String encoding
+    )
+    {
+        this.encoding = (encoding != null) ? encoding : DEFAULT_STRING_ENCODING;
+    }
+
+  @JsonProperty
+  public String getEncoding()
+    {
+        return encoding;
+    }
+
+  @Override
+  public KafkaHeaderReader createReader(
+          Headers headers,
+          long timestamp,
+          String headerLabelPrefix,
+          String recordTimestampLabelPrefix)
+  {
+      return new KafkaStringHeaderReader(
+                    headers,
+                    this.encoding,
+                    timestamp,
+                    headerLabelPrefix,
+                    recordTimestampLabelPrefix
+      );
+  }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof KafkaStringHeaderFormat)) {
+            return false;
+        }
+        KafkaStringHeaderFormat that = (KafkaStringHeaderFormat) o;
+        return Objects.equals(encoding, that.encoding);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(encoding);
+    }
+
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderReader.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KafkaStringHeaderReader implements KafkaHeaderReader
+{
+  private static final Logger log = new Logger(KafkaStringHeaderReader.class);
+  private final Headers headers;
+  private final long timestamp;
+  private final String headerLabelPrefix;
+  private final String timestampLabelPrefix;
+  private final String encoding;
+
+  public KafkaStringHeaderReader(Headers headers,
+                                 String encoding,
+                                 long timestamp,
+                                 String headerLabelPrefix,
+                                 String timestampLabelPrefix)
+  {
+    this.headers = headers;
+    this.encoding = encoding;
+    this.timestamp = timestamp;
+    this.headerLabelPrefix = headerLabelPrefix;
+    this.timestampLabelPrefix = timestampLabelPrefix;
+  }
+
+  @Override
+  public InputRow read() throws IOException
+  {
+    List<InputRow> rows = new ArrayList<>();
+    Map<String, Object> event = new HashMap<>();
+    List<String> dimensions = new ArrayList<String>();
+    for (Header hdr : headers) {
+      String s = new String(hdr.value(), this.encoding);
+      String newKey = this.headerLabelPrefix + hdr.key();
+      event.put(newKey, s);
+      dimensions.add(newKey);
+    }
+    // Save the record timestamp as a header attribute
+    event.put(this.timestampLabelPrefix + "timestamp", this.timestamp);
+    return new MapBasedInputRow(timestamp, dimensions, event);
+  }
+}

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskModule.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.TypeLiteral;
+import org.apache.druid.data.input.kafkainput.KafkaInputFormat;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorSpec;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTuningConfig;
@@ -49,7 +50,8 @@ public class KafkaIndexTaskModule implements DruidModule
                 new NamedType(KafkaIndexTaskTuningConfig.class, "KafkaTuningConfig"),
                 new NamedType(KafkaSupervisorTuningConfig.class, "kafka"),
                 new NamedType(KafkaSupervisorSpec.class, "kafka"),
-                new NamedType(KafkaSamplerSpec.class, "kafka")
+                new NamedType(KafkaSamplerSpec.class, "kafka"),
+                new NamedType(KafkaInputFormat.class, "kafka-input")
             )
     );
   }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.JsonInputFormat;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+public class KafkaInputFormatTest {
+    private KafkaRecordEntity inputEntity;
+    private long timestamp = DateTimes.of("2021-06-24").getMillis();
+    private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(new Header() {
+             @Override
+             public String key() { return "encoding"; }
+             @Override
+             public byte[] value() { return "application/json".getBytes(StandardCharsets.UTF_8); }
+             },
+            new Header() {
+                @Override
+                public String key() { return "kafkapkc"; }
+                @Override
+                public byte[] value() { return "pkc-bar".getBytes(StandardCharsets.UTF_8); }
+            });
+    private KafkaInputFormat format;
+
+    @Before
+    public void setUp()
+    {
+        format = new KafkaInputFormat(
+                new KafkaStringHeaderFormat(null),
+                // Key Format
+                new JsonInputFormat(
+                        new JSONPathSpec(true, ImmutableList.of()),
+                        null, null, false //make sure JsonReader is used
+                ),
+                // Value Format
+                new JsonInputFormat(
+                        new JSONPathSpec(
+                                true,
+                                ImmutableList.of(
+                                        new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz", "baz"),
+                                        new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz2", "baz2"),
+                                        new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
+                                        new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
+                                        new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
+                                        new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                                )
+                        ),
+                        null, null, false //make sure JsonReader is used
+                ),
+                "kafka.newheader.", "kafka.newkey.", "kafka.newts."
+        );
+    }
+
+    @Test
+    public void testWithHeaderKeyAndValue() throws IOException {
+        final byte[] key = StringUtils.toUtf8(
+                "{\n"
+                        + "    \"key\": \"sampleKey\"\n"
+                        + "}");
+
+        final byte[] payload = StringUtils.toUtf8(
+                "{\n"
+                        + "    \"timestamp\": \"2021-06-24\",\n"
+                        + "    \"bar\": null,\n"
+                        + "    \"foo\": \"x\",\n"
+                        + "    \"baz\": 4,\n"
+                        + "    \"o\": {\n"
+                        + "        \"mg\": 1\n"
+                        + "    }\n"
+                        + "}");
+
+        Headers headers = new RecordHeaders(SAMPLE_HEADERS);
+        inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
+                "sample", 0, 0, timestamp,
+                null, null, 0, 0,
+                key, payload, headers));
+
+        final InputEntityReader reader = format.createReader(
+                new InputRowSchema(
+                        new TimestampSpec("timestamp", "iso", null),
+                        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
+                                "bar", "foo",
+                                "kafka.newheader.encoding",
+                                "kafka.newheader.kafkapkc",
+                                "kafka.newts.timestamp"
+                                ))),
+                        Collections.emptyList()
+                ),
+                inputEntity,
+                null
+        );
+
+        final int numExpectedIterations = 1;
+        try (CloseableIterator<InputRow> iterator = reader.read()) {
+            int numActualIterations = 0;
+            while (iterator.hasNext()) {
+
+                final InputRow row = iterator.next();
+
+                // Payload verifications
+                Assert.assertEquals(DateTimes.of("2021-06-24"), row.getTimestamp());
+                Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+                Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+                Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+                Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+                Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+
+                // Header verification
+                Assert.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
+                Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
+                Assert.assertEquals(String.valueOf(DateTimes.of("2021-06-24").getMillis()),
+                        Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp")));
+
+                // Key verification
+                Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+
+                Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+                Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
+                Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+
+                numActualIterations++;
+            }
+
+            Assert.assertEquals(numExpectedIterations, numActualIterations);
+        }
+    }
+
+    @Test
+    public void testWithOutKey() throws IOException {
+        final byte[] payload = StringUtils.toUtf8(
+                "{\n"
+                        + "    \"timestamp\": \"2021-06-24\",\n"
+                        + "    \"bar\": null,\n"
+                        + "    \"foo\": \"x\",\n"
+                        + "    \"baz\": 4,\n"
+                        + "    \"o\": {\n"
+                        + "        \"mg\": 1\n"
+                        + "    }\n"
+                        + "}");
+
+        Headers headers = new RecordHeaders(SAMPLE_HEADERS);
+        inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
+                "sample", 0, 0, timestamp,
+                null, null, 0, 0,
+                null, payload, headers));
+
+        final InputEntityReader reader = format.createReader(
+                new InputRowSchema(
+                        new TimestampSpec("timestamp", "iso", null),
+                        new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
+                                "bar", "foo",
+                                "kafka.newheader.encoding",
+                                "kafka.newheader.kafkapkc",
+                                "kafka.newts.timestamp"
+                        ))),
+                        Collections.emptyList()
+                ),
+                inputEntity,
+                null
+        );
+
+        final int numExpectedIterations = 1;
+        try (CloseableIterator<InputRow> iterator = reader.read()) {
+            int numActualIterations = 0;
+            while (iterator.hasNext()) {
+
+                final InputRow row = iterator.next();
+
+                // Key verification
+                Assert.assertTrue(row.getDimension("kafka.newkey.key").isEmpty());
+                numActualIterations++;
+            }
+
+            Assert.assertEquals(numExpectedIterations, numActualIterations);
+        }
+
+    }
+}

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.kafkainput;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.*;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+
+public class KafkaStringHeaderFormatTest {
+    private KafkaRecordEntity inputEntity;
+    private long timestamp = DateTimes.of("2021-06-24T00:00:00.000Z").getMillis();
+    private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(new Header() {
+        @Override
+        public String key() { return "encoding"; }
+        @Override
+        public byte[] value() { return "application/json".getBytes(StandardCharsets.UTF_8); }
+    },
+        new Header() {
+            @Override
+            public String key() { return "kafkapkc"; }
+            @Override
+            public byte[] value() { return "pkc-bar".getBytes(StandardCharsets.UTF_8); }
+        });
+
+    @Test
+    public void testDefaultHeaderFormat() throws IOException {
+        String headerLabelPrefix = "test.kafka.header.";
+        String timestampLablePrefix = "test.kafka.newts.";
+        Headers headers = new RecordHeaders(SAMPLE_HEADERS);
+        inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
+                "sample", 0, 0, timestamp,
+                null, null, 0, 0,
+                null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers));
+        InputRow expectedResults = new MapBasedInputRow(
+                timestamp,
+                ImmutableList.of(
+                        "test.kafka.header.encoding",
+                        "test.kafka.header.kafkapkc",
+                        "test.kafka.newts.timestamp"
+                ),
+                ImmutableMap.of(
+                        "test.kafka.header.encoding",
+                        "application/json",
+                        "test.kafka.header.kafkapkc",
+                        "pkc-bar",
+                        "test.kafka.newts.timestamp",
+                        DateTimes.of("2021-06-24T00:00:00.000Z").getMillis()
+                )
+        );
+
+        KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat(null);
+        KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(),
+                                                                    inputEntity.getRecord().timestamp(),
+                                                                    headerLabelPrefix,
+                                                                    timestampLablePrefix);
+        Assert.assertEquals(expectedResults, headerParser.read());
+    }
+
+    @Test
+    public void testASCIIHeaderFormat() throws IOException {
+        Iterable<Header> HEADERS = ImmutableList.of(
+                new Header() {
+                    @Override
+                    public String key() { return "encoding"; }
+                    @Override
+                    public byte[] value() { return "application/json".getBytes(StandardCharsets.US_ASCII); }
+                },
+                new Header() {
+                    @Override
+                    public String key() { return "kafkapkc"; }
+                    @Override
+                    public byte[] value() { return "pkc-bar".getBytes(StandardCharsets.US_ASCII); }
+        });
+
+        String headerLabelPrefix = "test.kafka.header.";
+        String timestampLablePrefix = "test.kafka.newts.";
+        Headers headers = new RecordHeaders(HEADERS);
+        inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
+                "sample", 0, 0, timestamp,
+                null, null, 0, 0,
+                null, "sampleValue".getBytes(StandardCharsets.UTF_8), headers));
+        InputRow expectedResults = new MapBasedInputRow(
+                timestamp,
+                ImmutableList.of(
+                        "test.kafka.header.encoding",
+                        "test.kafka.header.kafkapkc",
+                        "test.kafka.newts.timestamp"
+                ),
+                ImmutableMap.of(
+                        "test.kafka.header.encoding",
+                        "application/json",
+                        "test.kafka.header.kafkapkc",
+                        "pkc-bar",
+                        "test.kafka.newts.timestamp",
+                        DateTimes.of("2021-06-24T00:00:00.000Z").getMillis()
+                )
+        );
+
+        KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat("US-ASCII");
+        KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(),
+                inputEntity.getRecord().timestamp(),
+                headerLabelPrefix,
+                timestampLablePrefix);
+
+        MapBasedInputRow row = (MapBasedInputRow)headerParser.read();
+        Assert.assertEquals(expectedResults, headerParser.read());
+    }
+}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Kafka input format initial code review for lab testing.

Tested it on local setup

On metrics and storage topics briefly from sandbox clusters
Throughput testing for 10 min interval from sandbox


#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
