### PR TITLE
Adding redirectParam to add custom callback url

### DIFF
--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jAuthenticator.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jAuthenticator.java
@@ -31,8 +31,11 @@ import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.Authenticator;
 import org.pac4j.core.config.Config;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.http.callback.CallbackUrlResolver;
 import org.pac4j.core.http.callback.NoParameterCallbackUrlResolver;
 import org.pac4j.core.http.url.DefaultUrlResolver;
+import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 
@@ -141,7 +144,24 @@ public class Pac4jAuthenticator implements Authenticator
 
     OidcClient oidcClient = new OidcClient(oidcConf);
     oidcClient.setUrlResolver(new DefaultUrlResolver(true));
-    oidcClient.setCallbackUrlResolver(new NoParameterCallbackUrlResolver());
+    if (pac4jCommonConfig.getCustomCallbackUrl() != null) {
+      oidcClient.setCallbackUrlResolver(
+          new CallbackUrlResolver() {
+            @Override
+            public String compute(UrlResolver urlResolver, String url, String clientName, WebContext context)
+            {
+              return pac4jCommonConfig.getCustomCallbackUrl();
+            }
+            @Override
+            public boolean matches(String var1, WebContext var2)
+            {
+              return false;
+            }
+          }
+      );
+    } else {
+      oidcClient.setCallbackUrlResolver(new NoParameterCallbackUrlResolver());
+    }
 
     // This is used by OidcClient in various places to make HTTPrequests.
     if (sslSocketFactory != null) {

--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jCommonConfig.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jCommonConfig.java
@@ -36,16 +36,21 @@ public class Pac4jCommonConfig
   @JsonProperty
   private final Duration readTimeout;
 
+  @JsonProperty
+  private final String customCallbackUrl;
+
   @JsonCreator
   public Pac4jCommonConfig(
       @JsonProperty("enableCustomSslContext") boolean enableCustomSslContext,
       @JsonProperty("cookiePassphrase") PasswordProvider cookiePassphrase,
-      @JsonProperty("readTimeout") Duration readTimeout
+      @JsonProperty("readTimeout") Duration readTimeout,
+      @JsonProperty("customCallbackUrl") String customCallbackUrl
   )
   {
     this.enableCustomSslContext = enableCustomSslContext;
     this.cookiePassphrase = Preconditions.checkNotNull(cookiePassphrase, "null cookiePassphrase");
     this.readTimeout = readTimeout == null ? Duration.millis(5000) : readTimeout;
+    this.customCallbackUrl = customCallbackUrl;
   }
 
   @JsonProperty
@@ -64,5 +69,11 @@ public class Pac4jCommonConfig
   public Duration getReadTimeout()
   {
     return readTimeout;
+  }
+
+  @JsonProperty
+  public String getCustomCallbackUrl()
+  {
+    return customCallbackUrl;
   }
 }

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jCommonConfigTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jCommonConfigTest.java
@@ -46,4 +46,27 @@ public class Pac4jCommonConfigTest
     Assert.assertEquals(10_000L, conf.getReadTimeout().getMillis());
     Assert.assertTrue(conf.isEnableCustomSslContext());
   }
+
+  @Test
+  public void testCustomCallbackUrl() throws Exception
+  {
+    ObjectMapper jsonMapper = new DefaultObjectMapper();
+
+    String jsonStr = "{\n"
+                     + "  \"cookiePassphrase\": \"testpass\",\n"
+                     + "  \"readTimeout\": \"PT10S\",\n"
+                     + "  \"enableCustomSslContext\": true,\n"
+                     + "  \"customCallbackUrl\": \"http://testCallback.com\"\n"
+                     + "}\n";
+
+    Pac4jCommonConfig conf = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(jsonMapper.readValue(jsonStr, Pac4jCommonConfig.class)),
+        Pac4jCommonConfig.class
+    );
+
+    Assert.assertEquals("testpass", conf.getCookiePassphrase().getPassword());
+    Assert.assertEquals(10_000L, conf.getReadTimeout().getMillis());
+    Assert.assertTrue(conf.isEnableCustomSslContext());
+    Assert.assertEquals("http://testCallback.com", conf.getCustomCallbackUrl());
+  }
 }


### PR DESCRIPTION
Issue:
https://github.com/apache/druid/issues/11437

Context:
https://www.pac4j.org/blog/understanding-the-callback-endpoint.html

While using Zeppelin + Knox, knox provides a parameter to add custom callback url
https://medium.com/data-collective/apache-zeppelin-oauth-integration-using-apache-knox-dea2362e3dda
"knoxJwtRealm.redirectParam = originalUrl"

I have used the same name for this new config and overrided  the compute method in NoParameterCallbackUrlResolver class.

Works fine in local setup, next step is to test in lab.

