### PR TITLE
[METRICS-3570] Fixed forbiddenapis error

### DIFF
--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -20,6 +20,7 @@
 package org.apache.druid.data.input.opencensus.protobuf;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
@@ -40,7 +41,6 @@ import org.apache.druid.utils.CollectionUtils;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -137,7 +137,7 @@ public class OpenCensusProtobufReader implements InputEntityReader
     for (TimeSeries ts : metric.getTimeseriesList()) {
       final LabelContext labelContext = (millis, metricName, value) -> {
         // Add common resourceLabels.
-        Map<String, Object> event = new HashMap<>(capacity);
+        Map<String, Object> event = Maps.newHashMapWithExpectedSize(capacity);
         event.putAll(resourceLabelsMap);
         // Add metric labels
         for (int i = 0; i < metric.getMetricDescriptor().getLabelKeysCount(); i++) {


### PR DESCRIPTION
When we run "mvn install" on our project, forbiddenapi check fails with the following error
`[ERROR] Failed to execute goal de.thetaphi:forbiddenapis:2.6:check (compile) on project druid-opencensus-extensions: Check for forbidden API calls failed, see log.`

`[ERROR] Forbidden method invocation: java.util.HashMap#<init>(int) [Use com.google.common.collect.Maps#newHashMapWithExpectedSize(int) instead]`

`[ERROR]   in org.apache.druid.data.input.opencensus.protobuf.OpenCensusProtobufReader (OpenCensusProtobufReader.java:140)
`
Now it's fixed 