### PR TITLE
[METRICS-3631] Added compile phases before checks

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,7 +63,7 @@ blocks:
 
         - name: "forbidden api checks"
           commands:
-            - ${MVN} compile ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+            - ${MVN} test-compile ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
             - ${MVN} forbiddenapis:check forbiddenapis:testCheck --fail-at-end
 
         - name: "pmd checks"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -50,6 +50,7 @@ blocks:
       jobs:
         - name: "animal sniffer checks"
           commands:
+            - ${MVN} test-compile ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
             - ${MVN} animal-sniffer:check --fail-at-end
 
         - name: "checkstyle"
@@ -62,6 +63,7 @@ blocks:
 
         - name: "forbidden api checks"
           commands:
+            - ${MVN} compile ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
             - ${MVN} forbiddenapis:check forbiddenapis:testCheck --fail-at-end
 
         - name: "pmd checks"


### PR DESCRIPTION
### Description

Add compile(test-compile) phase before run checks, because semaphore `cache store` command caches only `target` folder of druid directory, not `target` folders of each directories. 


##### Key changed/added classes in this PR
 * Add compile phase before run `forbiddenapi` check
 * Add compile-test phase before run `animal sniffer` check
