### PR TITLE
OpenTelemetry Emitter Extension

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -434,6 +434,8 @@
                                         <argument>org.apache.druid.extensions.contrib:druid-opencensus-extensions</argument>
                                         <argument>-c</argument>
                                         <argument>io.confluent.druid.extensions:confluent-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:opentelemetry-emitter</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/extensions-contrib/opentelemetry-emitter/README.md
+++ b/extensions-contrib/opentelemetry-emitter/README.md
@@ -7,7 +7,7 @@ The OpenTelemetry emitter generates OpenTelemetry Spans for queries.
 
 ### Enabling
 
-Load the plugin and enable the emitter in `common.runtime.properties`:
+Load the plugin and enable the emitter in `common.runtime.properties`.
 
 Load the plugin:
 
@@ -24,38 +24,71 @@ druid.emitter=opentelemetry
 *_Don't forget to remove the line_ `druid.emitter=noop` _to avoid rewriting_.
 
 ## Testing
-###Zipkin
-Run zipkin docker container
+### Part 1: Run zipkin and otel-collector
+Create `docker-compose.yaml` in your working dir:
 ```
-docker run -d -p 9411:9411 openzipkin/zipkin
-```
-Zipkin will be available at `http://localhost:9411`.
+version: "2"
+services:
 
-Add zipkin dependency to `extensions-contrib/opentelemetry-emitter/pom.xml`:
-```
-<dependency>
-  <groupId>io.opentelemetry</groupId>
-  <artifactId>opentelemetry-exporter-zipkin</artifactId>
-  <version>${your.version}</version>
-</dependency>
+  zipkin-all-in-one:
+    image: openzipkin/zipkin:latest
+    ports:
+      - "9411:9411"
+
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    command: ["--config=otel-local-config.yaml", "${OTELCOL_ARGS}"]
+    volumes:
+      - ${PWD}/config.yaml:/otel-local-config.yaml
+    ports:
+      - "4317:4317"
 ```
 
-Run:
+Create `config.yaml` file with configuration for otel-collector:
+```
+version: "2"
+receivers:
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  zipkin:
+    endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
+    format: proto
+
+  logging:
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, zipkin]
+```
+*_How to configure otel-collector you can read [here](https://opentelemetry.io/docs/collector/configuration/)._
+
+Run otel-collector and zipkin.
+```
+docker-compose up
+```
+
+### Part 2: Run druid
+Build druid:
 
 ```
-mvn package
+mvn clean install -Pdist
 tar -C /tmp -xf distribution/target/apache-druid-0.21.0-bin.tar.gz
 cd /tmp/apache-druid-0.21.0
 ```
 
 
 Edit `conf/druid/single-server/micro-quickstart/_common/common.runtime.properties` to enable
-the emitter (see `Configuration` section above). Set the following properties:
-```
-otel.traces.exporter=zipkin
-otel.service.name=druid
-```
-[More about OpenTelemetry SDK Autoconfigure](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure)
+the emitter (see `Configuration` section above).
 
 Start the quickstart:
 
@@ -63,108 +96,23 @@ Start the quickstart:
 bin/start-micro-quickstart
 ```
 
-Load sampel data - [example](https://druid.apache.org/docs/latest/tutorials/index.html#step-4-load-data)
+Load sampel data - [example](https://druid.apache.org/docs/latest/tutorials/index.html#step-4-load-data).
 
-Then you can send queries using `curl` and a query file `query.json`:
+### Part 3: Send queries
+
+Create `query.json`:
+```
+{
+   "query":"YOUR QUERY",
+   "context":{
+      "traceparent":"00-54ef39243e3feb12072e0f8a74c1d55a-ad6d5b581d7c29c1-01"
+   }
+}
+```
+
+Send query:
 ```
 curl -XPOST -H'Content-Type: application/json' http://localhost:8888/druid/v2/sql/ -d @query.json
 ```
 
-To test propagation run simple server which read query from stdin:
-```
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Scanner;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.context.Context;
-import io.opentelemetry.context.Scope;
-import io.opentelemetry.context.propagation.TextMapSetter;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.util.EntityUtils;
-import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-public class Main
-{
-
-  private static String process(String in) throws IOException
-  {
-    Map<String, Object> map = new HashMap<>();
-    map.put("query", in);
-    Map<String, Object> contextMap = new HashMap<>();
-
-    Tracer tracer = GlobalOpenTelemetry.getTracer("Simple server");
-    Span outGoing = tracer.spanBuilder("Simple server").setSpanKind(SpanKind.CLIENT).startSpan();
-    TextMapSetter<Map<String, Object>> setter =
-        (carrier, key, value) -> {
-          // Insert the context as Header
-          if (carrier != null) {
-            carrier.put(key, value);
-          }
-        };
-
-
-    CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-
-    String result = "";
-    try (Scope scope = outGoing.makeCurrent()) {
-      // store context
-      GlobalOpenTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), contextMap, setter);
-      map.put("context", contextMap);
-      ObjectMapper objectMapper = new ObjectMapper();
-      ByteArrayOutputStream baot = new ByteArrayOutputStream();
-      objectMapper.writeValue(baot, map);
-
-      System.out.println("Request " + baot);
-
-      // make request
-      HttpPost request = new HttpPost("http://localhost:8888/druid/v2/sql/");
-      StringEntity params = new StringEntity(baot.toString());
-      request.addHeader("Content-Type", "application/json");
-      request.setEntity(params);
-      HttpResponse res = httpClient.execute(request);
-      HttpEntity entity = res.getEntity();
-      result = EntityUtils.toString(entity, "UTF-8").trim();
-    }
-    catch (Exception ex) {
-      System.out.println(ex.getMessage());
-    }
-    finally {
-      httpClient.close();
-    }
-    outGoing.end();
-    return result;
-  }
-
-  public static void main(String[] args) throws IOException
-  {
-    System.setProperty("otel.service.name", "Simple server");
-    System.setProperty("otel.traces.exporter", "zipkin");
-
-    OpenTelemetrySdkAutoConfiguration.initialize();
-
-    while (true) {
-      Scanner scanner = new Scanner(System.in);
-      String in = scanner.nextLine();
-      if (in.equals("exit")) {
-        break;
-      }
-      System.out.println(process(in));
-    }
-  }
-}
-```
-
-###Otel Collector
-Will be added.
+Then open `http://localhost:9411/zipkin/` and you can see there your spans.

--- a/extensions-contrib/opentelemetry-emitter/README.md
+++ b/extensions-contrib/opentelemetry-emitter/README.md
@@ -21,6 +21,150 @@ Enable the emitter:
 druid.emitter=opentelemetry
 ```
 
-## Testing
+*_Don't forget to remove the line_ `druid.emitter=noop` _to avoid rewriting_.
 
+## Testing
+###Zipkin
+Run zipkin docker container
+```
+docker run -d -p 9411:9411 openzipkin/zipkin
+```
+Zipkin will be available at `http://localhost:9411`.
+
+Add zipkin dependency to `extensions-contrib/opentelemetry-emitter/pom.xml`:
+```
+<dependency>
+  <groupId>io.opentelemetry</groupId>
+  <artifactId>opentelemetry-exporter-zipkin</artifactId>
+  <version>${your.version}</version>
+</dependency>
+```
+
+Run:
+
+```
+mvn package
+tar -C /tmp -xf distribution/target/apache-druid-0.21.0-bin.tar.gz
+cd /tmp/apache-druid-0.21.0
+```
+
+
+Edit `conf/druid/single-server/micro-quickstart/_common/common.runtime.properties` to enable
+the emitter (see `Configuration` section above). Set the following properties:
+```
+otel.traces.exporter=zipkin
+otel.service.name=druid
+```
+[More about OpenTelemetry SDK Autoconfigure](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure)
+
+Start the quickstart:
+
+```
+bin/start-micro-quickstart
+```
+
+Load sampel data - [example](https://druid.apache.org/docs/latest/tutorials/index.html#step-4-load-data)
+
+Then you can send queries using `curl` and a query file `query.json`:
+```
+curl -XPOST -H'Content-Type: application/json' http://localhost:8888/druid/v2/sql/ -d @query.json
+```
+
+To test propagation run simple server which read query from stdin:
+```
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class Main
+{
+
+  private static String process(String in) throws IOException
+  {
+    Map<String, Object> map = new HashMap<>();
+    map.put("query", in);
+    Map<String, Object> contextMap = new HashMap<>();
+
+    Tracer tracer = GlobalOpenTelemetry.getTracer("Simple server");
+    Span outGoing = tracer.spanBuilder("Simple server").setSpanKind(SpanKind.CLIENT).startSpan();
+    TextMapSetter<Map<String, Object>> setter =
+        (carrier, key, value) -> {
+          // Insert the context as Header
+          if (carrier != null) {
+            carrier.put(key, value);
+          }
+        };
+
+
+    CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+
+    String result = "";
+    try (Scope scope = outGoing.makeCurrent()) {
+      // store context
+      GlobalOpenTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), contextMap, setter);
+      map.put("context", contextMap);
+      ObjectMapper objectMapper = new ObjectMapper();
+      ByteArrayOutputStream baot = new ByteArrayOutputStream();
+      objectMapper.writeValue(baot, map);
+
+      System.out.println("Request " + baot);
+
+      // make request
+      HttpPost request = new HttpPost("http://localhost:8888/druid/v2/sql/");
+      StringEntity params = new StringEntity(baot.toString());
+      request.addHeader("Content-Type", "application/json");
+      request.setEntity(params);
+      HttpResponse res = httpClient.execute(request);
+      HttpEntity entity = res.getEntity();
+      result = EntityUtils.toString(entity, "UTF-8").trim();
+    }
+    catch (Exception ex) {
+      System.out.println(ex.getMessage());
+    }
+    finally {
+      httpClient.close();
+    }
+    outGoing.end();
+    return result;
+  }
+
+  public static void main(String[] args) throws IOException
+  {
+    System.setProperty("otel.service.name", "Simple server");
+    System.setProperty("otel.traces.exporter", "zipkin");
+
+    OpenTelemetrySdkAutoConfiguration.initialize();
+
+    while (true) {
+      Scanner scanner = new Scanner(System.in);
+      String in = scanner.nextLine();
+      if (in.equals("exit")) {
+        break;
+      }
+      System.out.println(process(in));
+    }
+  }
+}
+```
+
+###Otel Collector
 Will be added.

--- a/extensions-contrib/opentelemetry-emitter/README.md
+++ b/extensions-contrib/opentelemetry-emitter/README.md
@@ -1,0 +1,26 @@
+# OpenTracing Emitter
+
+The OpenTelemetry emitter generates OpenTelemetry Spans for queries.
+
+
+## Configuration
+
+### Enabling
+
+Load the plugin and enable the emitter in `common.runtime.properties`:
+
+Load the plugin:
+
+```
+druid.extensions.loadList=[..., "opentelemetry-emitter"]
+```
+
+Enable the emitter:
+
+```
+druid.emitter=opentelemetry
+```
+
+## Testing
+
+Will be added.

--- a/extensions-contrib/opentelemetry-emitter/README.md
+++ b/extensions-contrib/opentelemetry-emitter/README.md
@@ -1,4 +1,4 @@
-# OpenTracing Emitter
+# OpenTelemetry Emitter
 
 The OpenTelemetry emitter generates OpenTelemetry Spans for queries.
 
@@ -15,13 +15,20 @@ Load the plugin:
 druid.extensions.loadList=[..., "opentelemetry-emitter"]
 ```
 
-Enable the emitter:
+Then there are 2 options:
+
+* You want to use only `opentelemetry-emitter` 
 
 ```
 druid.emitter=opentelemetry
 ```
 
-*_Don't forget to remove the line_ `druid.emitter=noop` _to avoid rewriting_.
+* You want to use `opentelemetry-emitter` with others emitters
+```
+druid.emitter=composing
+druid.emitter.composing.emitters=[..., "opentelemetry"]
+```
+_*More about Druid configuration [here](https://druid.apache.org/docs/0.22.0/configuration/index.html)._
 
 ## Testing
 ### Part 1: Run zipkin and otel-collector
@@ -77,8 +84,8 @@ Run otel-collector and zipkin.
 docker-compose up
 ```
 
-### Part 2: Run druid
-Build druid:
+### Part 2: Run Druid
+Build Druid:
 
 ```
 mvn clean install -Pdist
@@ -90,20 +97,20 @@ cd /tmp/apache-druid-0.21.0
 Edit `conf/druid/single-server/micro-quickstart/_common/common.runtime.properties` to enable
 the emitter (see `Configuration` section above).
 
-Start the quickstart:
-
+Start the quickstart with the apppropriate environment variables for opentelemetry autoconfiguration:
 ```
-bin/start-micro-quickstart
+OTEL_SERVICE_NAME="org.apache.druid" OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317" bin/start-micro-quickstart
 ```
+*_More about opentelemetry autoconfiguration [here](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure)_
 
-Load sampel data - [example](https://druid.apache.org/docs/latest/tutorials/index.html#step-4-load-data).
+Load sample data - [example](https://druid.apache.org/docs/latest/tutorials/index.html#step-4-load-data).
 
 ### Part 3: Send queries
 
 Create `query.json`:
 ```
 {
-   "query":"YOUR QUERY",
+   "query":"SELECT COUNT(*) as total FROM wiki WHERE countryName IS NOT NULL",
    "context":{
       "traceparent":"00-54ef39243e3feb12072e0f8a74c1d55a-ad6d5b581d7c29c1-01"
    }

--- a/extensions-contrib/opentelemetry-emitter/README.md
+++ b/extensions-contrib/opentelemetry-emitter/README.md
@@ -4,19 +4,19 @@ The [OpenTelemetry](https://opentelemetry.io/) emitter generates OpenTelemetry S
 
 ## How OpenTelemetry emitter works
 
-The [OpenTelemetry](https://opentelemetry.io/) emitter processes`ServiceMetricEvent` type of event with a `query/time`
-metric. It extacts OpenTelemetry context
-from [druid context](https://druid.apache.org/docs/latest/querying/query-context.html). To link druid spans to parent
-trace druid context should contain `traceparent` key, at least. More
-about [context propagation](https://www.w3.org/TR/trace-context/). If there is no `traceparent` key is provided, then
-spans are created without `parentTraceId` and link to no parent. Also, the emitter adds other druid context entries to
-the span attributes.
+The [OpenTelemetry](https://opentelemetry.io/) emitter processes `ServiceMetricEvent` events for the `query/time`
+metric. It extracts OpenTelemetry context from
+the [query context](https://druid.apache.org/docs/latest/querying/query-context.html). To link druid spans to parent
+traces, the query context should contain at least `traceparent` key.
+See [context propagation](https://www.w3.org/TR/trace-context/) for more information. If no `traceparent` key is
+provided, then spans are created without `parentTraceId` and are not linked to the parent span. In addition, the emitter
+also adds other druid context entries to the span attributes.
 
 ## Configuration
 
 ### Enabling
 
-Load the plugin and enable the emitter in `common.runtime.properties`.
+To enable the OpenTelemetry emitter, add the extension and enable the emitter in `common.runtime.properties`.
 
 Load the plugin:
 

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -31,12 +31,14 @@
   <groupId>org.apache.druid.extensions.contrib</groupId>
   <artifactId>opentelemetry-emitter</artifactId>
   <name>opentelemetry-emitter</name>
-  <description>Extension support for emitting OpenTelemetry spans</description>
+  <description>Extension support for emitting OpenTelemetry spans for Druid queries</description>
 
   <properties>
     <opentelemetry.version>1.6.0</opentelemetry.version>
-    <opentelemetry.instrumentation.version>1.6.0-alpha</opentelemetry.instrumentation.version>
-    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+    <opentelemetry.instrumentation.version>1.6.2-alpha</opentelemetry.instrumentation.version>
+    <opentelemetry.autoinstrumentation.version>1.6.0-alpha</opentelemetry.autoinstrumentation.version>
+    <!-- These guava and grpc versions are used only in the opentelemetry-extension.
+      Look at build section for more details about shading. -->
     <shade.guava.version>30.1.1-jre</shade.guava.version>
     <shade.grpc.version>1.41.0</shade.grpc.version>
   </properties>
@@ -48,8 +50,6 @@
       <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
-
-    <!-- opentelemetry -->
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-otlp</artifactId>
@@ -73,15 +73,12 @@
       <version>${opentelemetry.instrumentation.version}</version>
       <type>pom</type>
     </dependency>
+    <!-- OpenTelemetry extension bundles the OpenTelemetry auto-instrumentation,
+      So it could potentially affect performance -->
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-      <version>${opentelemetry.instrumentation.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.perfmark</groupId>
-      <artifactId>perfmark-api</artifactId>
-      <version>0.24.0</version>
+      <version>${opentelemetry.autoinstrumentation.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -93,8 +90,15 @@
       <artifactId>guava</artifactId>
       <version>${shade.guava.version}</version>
     </dependency>
-    <!-- opentelemetry -->
-
+    <!-- explicitly include perfmark dependency of grpc we exclude from the shaded jar
+    Note: we could use promoteTransitiveDependencies=true in the shade plugin, but that promotes all
+    transitive dependencies as well, which unnecessarily pollutes the final pom -->
+    <dependency>
+      <groupId>io.perfmark</groupId>
+      <artifactId>perfmark-api</artifactId>
+      <version>0.23.0</version>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
@@ -110,8 +114,6 @@
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <!-- test -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -134,7 +136,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
             <id>opentelemetry-extension</id>
@@ -144,6 +145,10 @@
             </goals>
             <configuration>
               <transformers>
+                <!-- grpc stores service providers in META-INF/services/* files,
+                  so we need to relocate the class names of the implementation classes.
+                  More about SPI - https://docs.oracle.com/javase/tutorial/ext/basics/spi.html.
+                  https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html. -->
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <artifactSet>
@@ -151,7 +156,6 @@
                   <include>io.opentelemetry</include>
                   <include>io.grpc</include>
                   <include>com.google.guava</include>
-                  <include>io.perfmark</include>
                 </includes>
               </artifactSet>
               <relocations>
@@ -169,10 +173,6 @@
                 <relocation>
                   <pattern>io.opentelemetry</pattern>
                   <shadedPattern>org.apache.druid.opentelemetry.shaded.io.opentelemetry</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>io.perfmark</pattern>
-                  <shadedPattern>org.apache.druid.opentelemetry.shaded.io.perfmark</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <opentelemetry.version>1.6.0</opentelemetry.version>
     <opentelemetry.instrumentation.version>1.6.0-alpha</opentelemetry.instrumentation.version>
+    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+    <shade.guava.version>30.1.1-jre</shade.guava.version>
+    <shade.grpc.version>1.41.0</shade.grpc.version>
   </properties>
 
   <dependencies>
@@ -45,6 +48,8 @@
       <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- opentelemetry -->
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-otlp</artifactId>
@@ -74,10 +79,22 @@
       <version>${opentelemetry.instrumentation.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId> opentelemetry-exporter-otlp-http-trace</artifactId>
-      <version>${opentelemetry.version}</version>
+      <groupId>io.perfmark</groupId>
+      <artifactId>perfmark-api</artifactId>
+      <version>0.24.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>${shade.grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${shade.guava.version}</version>
+    </dependency>
+    <!-- opentelemetry -->
+
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
@@ -93,6 +110,8 @@
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- test -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -109,4 +128,57 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>opentelemetry-extension</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <artifactSet>
+                <includes>
+                  <include>io.opentelemetry</include>
+                  <include>io.grpc</include>
+                  <include>com.google.guava</include>
+                  <include>io.perfmark</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>org.apache.druid.opentelemetry.shaded.com.google.common</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.grpc</pattern>
+                  <shadedPattern>org.apache.druid.opentelemetry.shaded.io.grpc</shadedPattern>
+                  <includes>
+                    <include>io.grpc.*</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>io.opentelemetry</pattern>
+                  <shadedPattern>org.apache.druid.opentelemetry.shaded.io.opentelemetry</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.perfmark</pattern>
+                  <shadedPattern>org.apache.druid.opentelemetry.shaded.io.perfmark</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -46,10 +46,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.druid</groupId>
-      <artifactId>druid-server</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>provided</scope>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
@@ -93,6 +92,21 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.apache.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>0.21.0</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.druid.extensions.contrib</groupId>
+  <artifactId>opentelemetry-emitter</artifactId>
+  <name>opentelemetry-emitter</name>
+  <description>Extension support for emitting OpenTelemetry spans</description>
+
+  <properties>
+    <opentelemetry.version>1.6.0</opentelemetry.version>
+    <opentelemetry.instrumentation.version>1.6.0-alpha</opentelemetry.instrumentation.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-core</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-bom</artifactId>
+      <version>${opentelemetry.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-bom-alpha</artifactId>
+      <version>${opentelemetry.version}-alpha</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.instrumentation</groupId>
+      <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+      <version>${opentelemetry.instrumentation.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+      <version>${opentelemetry.instrumentation.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId> opentelemetry-exporter-otlp-http-trace</artifactId>
+      <version>${opentelemetry.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -36,13 +36,36 @@
   <properties>
     <opentelemetry.version>1.6.0</opentelemetry.version>
     <opentelemetry.instrumentation.version>1.6.2-alpha</opentelemetry.instrumentation.version>
-    <opentelemetry.autoinstrumentation.version>1.6.0-alpha</opentelemetry.autoinstrumentation.version>
     <!-- These guava and grpc versions are used only in the opentelemetry-extension.
       Look at build section for more details about shading. -->
     <shade.guava.version>30.1.1-jre</shade.guava.version>
     <shade.grpc.version>1.41.0</shade.grpc.version>
   </properties>
-
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom-alpha</artifactId>
+        <version>${opentelemetry.version}-alpha</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.opentelemetry.instrumentation</groupId>
+        <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+        <version>${opentelemetry.instrumentation.version}</version>
+        <type>pom</type>
+        <scope>compile</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.apache.druid</groupId>
@@ -53,32 +76,12 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-otlp</artifactId>
-      <version>${opentelemetry.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-bom</artifactId>
-      <version>${opentelemetry.version}</version>
-      <type>pom</type>
-    </dependency>
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-bom-alpha</artifactId>
-      <version>${opentelemetry.version}-alpha</version>
-      <type>pom</type>
-    </dependency>
-    <dependency>
-      <groupId>io.opentelemetry.instrumentation</groupId>
-      <artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
-      <version>${opentelemetry.instrumentation.version}</version>
-      <type>pom</type>
     </dependency>
     <!-- OpenTelemetry extension bundles the OpenTelemetry auto-instrumentation,
       So it could potentially affect performance -->
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-      <version>${opentelemetry.autoinstrumentation.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -117,11 +120,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -34,8 +34,8 @@
   <description>Extension support for emitting OpenTelemetry spans for Druid queries</description>
 
   <properties>
-    <opentelemetry.version>1.6.0</opentelemetry.version>
-    <opentelemetry.instrumentation.version>1.6.2-alpha</opentelemetry.instrumentation.version>
+    <opentelemetry.version>1.7.0</opentelemetry.version>
+    <opentelemetry.instrumentation.version>1.7.0-alpha</opentelemetry.instrumentation.version>
     <!-- These guava and grpc versions are used only in the opentelemetry-extension.
       Look at build section for more details about shading. -->
     <shade.guava.version>30.1.1-jre</shade.guava.version>

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/DruidContextTextMapGetter.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/DruidContextTextMapGetter.java
@@ -23,6 +23,11 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 
 import java.util.Map;
 
+/**
+ * Implementation of a text-based approach to read the W3C Trace Context from request.
+ * Opentelemetry context propagation - https://opentelemetry.io/docs/java/manual_instrumentation/#context-propagation
+ * W3C Trace Context - https://www.w3.org/TR/trace-context/
+ */
 public class DruidContextTextMapGetter implements TextMapGetter<Map<String, String>>
 {
   @Override

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/DruidContextTextMapGetter.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/DruidContextTextMapGetter.java
@@ -19,46 +19,24 @@
 
 package org.apache.druid.emitter.opentelemetry;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import io.opentelemetry.context.propagation.TextMapGetter;
 
-import javax.annotation.Nullable;
+import java.util.Map;
 
-public class OpenTelemetryEmitterConfig
+public class DruidContextTextMapGetter implements TextMapGetter<Map<String, String>>
 {
-  @JsonProperty
-  private final String protocol;
-
-  @JsonProperty
-  private final String endpoint;
-
-  @JsonProperty
-  private final String exporter;
-
-  @JsonCreator
-  public OpenTelemetryEmitterConfig(
-      @JsonProperty("protocol") @Nullable String protocol,
-      @JsonProperty("endpoint") @Nullable String endpoint,
-      @JsonProperty("exporter") @Nullable String exporter
-  )
+  @Override
+  public String get(Map<String, String> carrier, String key)
   {
-    this.protocol = protocol;
-    this.endpoint = endpoint;
-    this.exporter = exporter;
+    if (carrier.containsKey(key)) {
+      return carrier.get(key);
+    }
+    return null;
   }
 
-  public String getProtocol()
+  @Override
+  public Iterable<String> keys(Map<String, String> carrier)
   {
-    return protocol;
-  }
-
-  public String getEndpoint()
-  {
-    return endpoint;
-  }
-
-  public String getExporter()
-  {
-    return exporter;
+    return carrier.keySet();
   }
 }

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/DruidContextTextMapGetter.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/DruidContextTextMapGetter.java
@@ -25,46 +25,34 @@ import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 /**
- * Implementation of a text-based approach to read the W3C Trace Context from request.
+ * Implementation of a text-based approach to read the W3C Trace Context from the metric query context.
  * <a href="https://opentelemetry.io/docs/java/manual_instrumentation/#context-propagation">Context propagation</a>
  * <a href="https://www.w3.org/TR/trace-context/">W3C Trace Context</a>
  */
 @NotThreadSafe
 public class DruidContextTextMapGetter implements TextMapGetter<ServiceMetricEvent>
 {
-  private final Set<String> extractedKeys = new HashSet<>();
 
   @SuppressWarnings("unchecked")
   private Map<String, Object> getContext(ServiceMetricEvent event)
   {
     Object context = event.getUserDims().get("context");
-    if (!(context instanceof Map)) {
-      return Collections.emptyMap();
+    if (context instanceof Map) {
+      return (Map<String, Object>) context;
     }
-    return (Map<String, Object>) context;
-  }
-
-  public Set<String> getExtractedKeys()
-  {
-    return extractedKeys;
+    return Collections.emptyMap();
   }
 
   @Nullable
   @Override
   public String get(ServiceMetricEvent event, String key)
   {
-    String res = Optional.ofNullable(getContext(event).get(key)).map(Objects::toString).orElse(null);
-    if (res != null) {
-      extractedKeys.add(key);
-    }
-    return res;
+    return Optional.ofNullable(getContext(event).get(key)).map(Objects::toString).orElse(null);
   }
 
   @Override

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.opentelemetry;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.java.util.emitter.core.Emitter;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.joda.time.DateTime;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class OpenTelemetryEmitter implements Emitter
+{
+  private static final Logger log = new Logger(OpenTelemetryEmitter.class);
+  private final Tracer tracer;
+
+  OpenTelemetryEmitter()
+  {
+    tracer = GlobalOpenTelemetry.getTracer("druid-opentelemtry-extension");
+  }
+
+  @Override
+  public void start()
+  {
+    log.info("Starting OpenTelemetryEmitter");
+  }
+
+  @Override
+  public void emit(Event e)
+  {
+    if (!(e instanceof ServiceMetricEvent)) {
+      return;
+    }
+    ServiceMetricEvent event = (ServiceMetricEvent) e;
+
+    // We generate spans for the following types of events:
+    // query/time
+    if (!event.getMetric().equals("query/time")) {
+      return;
+    }
+    DateTime endTime = event.getCreatedTime();
+    DateTime startTime = event.getCreatedTime().minusMillis(event.getValue().intValue());
+
+    TextMapGetter<Map<String, String>> contextGetter =
+        new TextMapGetter<Map<String, String>>()
+        {
+          @Override
+          public String get(Map<String, String> carrier, String key)
+          {
+            if (carrier.containsKey(key)) {
+              return carrier.get(key);
+            }
+            return null;
+          }
+
+          @Override
+          public Iterable<String> keys(Map<String, String> carrier)
+          {
+            return carrier.keySet();
+          }
+        };
+
+    Context extractedContext = GlobalOpenTelemetry.getPropagators().getTextMapPropagator()
+                                                  .extract(Context.current(), getContextAsString(event), contextGetter);
+
+    try (Scope scope = extractedContext.makeCurrent()) {
+      Span span = tracer.spanBuilder(event.getService()).setStartTimestamp(
+          startTime.getMillis(),
+          TimeUnit.MILLISECONDS
+      ).startSpan();
+      span.end(endTime.getMillis(), TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private static Map<String, String> getContextAsString(ServiceMetricEvent event)
+  {
+    return getContext(event).entrySet().stream()
+                            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+  }
+
+  private static Map<String, Object> getContext(ServiceMetricEvent event)
+  {
+    Object context = event.getUserDims().get("context");
+    if (!(context instanceof Map)) {
+      return Collections.emptyMap();
+    }
+    return (Map<String, Object>) context;
+  }
+
+  @Override
+  public void flush() throws IOException
+  {
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+  }
+}

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.emitter.opentelemetry;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
@@ -35,20 +35,19 @@ import org.joda.time.DateTime;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class OpenTelemetryEmitter implements Emitter
 {
   private static final Logger log = new Logger(OpenTelemetryEmitter.class);
-  private static final DruidContextTextMapGetter DRUID_CONTEXT_MAP_GETTER = new DruidContextTextMapGetter();
   private final Tracer tracer;
   private final TextMapPropagator propagator;
 
-  OpenTelemetryEmitter()
+  OpenTelemetryEmitter(OpenTelemetry openTelemetry)
   {
-    tracer = GlobalOpenTelemetry.getTracer("druid-opentelemetry-extension");
-    propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
+    tracer = openTelemetry.getTracer("druid-opentelemetry-extension");
+    propagator = openTelemetry.getPropagators().getTextMapPropagator();
   }
 
   @Override
@@ -76,8 +75,8 @@ public class OpenTelemetryEmitter implements Emitter
 
   private void emitQueryTimeEvent(ServiceMetricEvent event)
   {
-    Map<String, String> druidContext = getContextAsString(event);
-    Context opentelemetryContext = propagator.extract(Context.current(), druidContext, DRUID_CONTEXT_MAP_GETTER);
+    DruidContextTextMapGetter druidContextTextMapGetter = new DruidContextTextMapGetter();
+    Context opentelemetryContext = propagator.extract(Context.current(), event, druidContextTextMapGetter);
 
     try (Scope scope = opentelemetryContext.makeCurrent()) {
       DateTime endTime = event.getCreatedTime();
@@ -86,17 +85,15 @@ public class OpenTelemetryEmitter implements Emitter
       Span span = tracer.spanBuilder(event.getService())
                         .setStartTimestamp(startTime.getMillis(), TimeUnit.MILLISECONDS)
                         .startSpan();
-      druidContext.forEach(span::setAttribute);
+      Set<String> extractedKeys = druidContextTextMapGetter.getExtractedKeys();
+
+      getContext(event).entrySet()
+                       .stream()
+                       .filter(entry -> entry.getValue() != null)
+                       .filter(entry -> !extractedKeys.contains(entry.getKey()))
+                       .forEach(entry -> span.setAttribute(entry.getKey(), entry.getValue().toString()));
       span.setStatus(StatusCode.OK).end(endTime.getMillis(), TimeUnit.MILLISECONDS);
     }
-  }
-
-  private static Map<String, String> getContextAsString(ServiceMetricEvent event)
-  {
-    return getContext(event).entrySet()
-                            .stream()
-                            .filter(entry -> entry.getValue() != null)
-                            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
   }
 
   private static Map<String, Object> getContext(ServiceMetricEvent event)

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
@@ -21,9 +21,11 @@ package org.apache.druid.emitter.opentelemetry;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.core.Emitter;
 import org.apache.druid.java.util.emitter.core.Event;
@@ -41,16 +43,18 @@ public class OpenTelemetryEmitter implements Emitter
   private static final Logger log = new Logger(OpenTelemetryEmitter.class);
   private static final DruidContextTextMapGetter DRUID_CONTEXT_MAP_GETTER = new DruidContextTextMapGetter();
   private final Tracer tracer;
+  private final TextMapPropagator propagator;
 
-  OpenTelemetryEmitter(Tracer tracer)
+  OpenTelemetryEmitter()
   {
-    this.tracer = tracer;
+    tracer = GlobalOpenTelemetry.getTracer("druid-opentelemetry-extension");
+    propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
   }
 
   @Override
   public void start()
   {
-    log.info("Starting OpenTelemetryEmitter");
+    log.debug("Starting OpenTelemetryEmitter");
   }
 
   @Override
@@ -72,28 +76,26 @@ public class OpenTelemetryEmitter implements Emitter
 
   private void emitQueryTimeEvent(ServiceMetricEvent event)
   {
-    Context context = GlobalOpenTelemetry.getPropagators()
-                                         .getTextMapPropagator()
-                                         .extract(Context.current(),
-                                                  getContextAsString(event),
-                                                  DRUID_CONTEXT_MAP_GETTER
-                                         );
+    Map<String, String> druidContext = getContextAsString(event);
+    Context opentelemetryContext = propagator.extract(Context.current(), druidContext, DRUID_CONTEXT_MAP_GETTER);
 
-    try (Scope scope = context.makeCurrent()) {
+    try (Scope scope = opentelemetryContext.makeCurrent()) {
       DateTime endTime = event.getCreatedTime();
       DateTime startTime = endTime.minusMillis(event.getValue().intValue());
 
-      Span span = tracer.spanBuilder(event.getService()).setStartTimestamp(
-          startTime.getMillis(),
-          TimeUnit.MILLISECONDS
-      ).startSpan();
-      span.end(endTime.getMillis(), TimeUnit.MILLISECONDS);
+      Span span = tracer.spanBuilder(event.getService())
+                        .setStartTimestamp(startTime.getMillis(), TimeUnit.MILLISECONDS)
+                        .startSpan();
+      druidContext.forEach(span::setAttribute);
+      span.setStatus(StatusCode.OK).end(endTime.getMillis(), TimeUnit.MILLISECONDS);
     }
   }
 
   private static Map<String, String> getContextAsString(ServiceMetricEvent event)
   {
-    return getContext(event).entrySet().stream()
+    return getContext(event).entrySet()
+                            .stream()
+                            .filter(entry -> entry.getValue() != null)
                             .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
   }
 

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
@@ -19,26 +19,6 @@
 
 package org.apache.druid.emitter.opentelemetry;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import javax.annotation.Nullable;
-
 public class OpenTelemetryEmitterConfig
 {
-  @JsonProperty
-  private final String endpoint;
-
-  @JsonCreator
-  public OpenTelemetryEmitterConfig(
-      @JsonProperty("endpoint") @Nullable String endpoint
-  )
-  {
-    this.endpoint = endpoint;
-  }
-
-  public String getEndpoint()
-  {
-    return endpoint;
-  }
 }

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.opentelemetry;
+
+public class OpenTelemetryEmitterConfig
+{
+}

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
@@ -27,38 +27,18 @@ import javax.annotation.Nullable;
 public class OpenTelemetryEmitterConfig
 {
   @JsonProperty
-  private final String protocol;
-
-  @JsonProperty
   private final String endpoint;
-
-  @JsonProperty
-  private final String exporter;
 
   @JsonCreator
   public OpenTelemetryEmitterConfig(
-      @JsonProperty("protocol") @Nullable String protocol,
-      @JsonProperty("endpoint") @Nullable String endpoint,
-      @JsonProperty("exporter") @Nullable String exporter
+      @JsonProperty("endpoint") @Nullable String endpoint
   )
   {
-    this.protocol = protocol;
     this.endpoint = endpoint;
-    this.exporter = exporter;
-  }
-
-  public String getProtocol()
-  {
-    return protocol;
   }
 
   public String getEndpoint()
   {
     return endpoint;
-  }
-
-  public String getExporter()
-  {
-    return exporter;
   }
 }

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.emitter.opentelemetry;
 
+/**
+ * The placeholder for future configurations but there is no configuration yet
+ */
 public class OpenTelemetryEmitterConfig
 {
 }

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.opentelemetry;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
+import org.apache.druid.guice.JsonConfigProvider;
+import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.java.util.emitter.core.Emitter;
+
+import java.util.Collections;
+import java.util.List;
+
+public class OpenTelemetryEmitterModule implements DruidModule
+{
+  private static final String EMITTER_TYPE = "opentelemetry";
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+    JsonConfigProvider.bind(binder, "druid.emitter." + EMITTER_TYPE, OpenTelemetryEmitterConfig.class);
+  }
+
+  @Provides
+  @ManageLifecycle
+  @Named(EMITTER_TYPE)
+  public Emitter getEmitter(OpenTelemetryEmitterConfig config, ObjectMapper mapper)
+  {
+    OpenTelemetrySdkAutoConfiguration.initialize();
+    return new OpenTelemetryEmitter();
+  }
+}

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
@@ -24,12 +24,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.google.inject.name.Named;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.sdk.autoconfigure.OpenTelemetrySdkAutoConfiguration;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.initialization.DruidModule;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.core.Emitter;
 
 import java.util.Collections;
@@ -37,7 +35,6 @@ import java.util.List;
 
 public class OpenTelemetryEmitterModule implements DruidModule
 {
-  private static final Logger log = new Logger(OpenTelemetryEmitterModule.class);
   private static final String EMITTER_TYPE = "opentelemetry";
 
   @Override
@@ -57,13 +54,7 @@ public class OpenTelemetryEmitterModule implements DruidModule
   @Named(EMITTER_TYPE)
   public Emitter getEmitter(OpenTelemetryEmitterConfig config, ObjectMapper mapper)
   {
-    String endpoint = config.getEndpoint();
-    if (endpoint != null) {
-      System.setProperty("otel.exporter.otlp.endpoint", endpoint);
-    }
-    System.setProperty("otel.service.name", "org.apache.druid");
-    log.info("Init OTel with otel.exporter.otlp.endpoint = " + endpoint);
     OpenTelemetrySdkAutoConfiguration.initialize();
-    return new OpenTelemetryEmitter(GlobalOpenTelemetry.getTracer("druid-opentelemetry-extension"));
+    return new OpenTelemetryEmitter();
   }
 }

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
@@ -57,23 +57,13 @@ public class OpenTelemetryEmitterModule implements DruidModule
   @Named(EMITTER_TYPE)
   public Emitter getEmitter(OpenTelemetryEmitterConfig config, ObjectMapper mapper)
   {
-    OpenTelemetrySdkAutoConfiguration.initialize();
-    String protocol = config.getProtocol();
     String endpoint = config.getEndpoint();
-    String exporter = config.getExporter();
-    if (protocol != null) {
-      System.setProperty("otel.experimental.exporter.otlp.traces.protocol", protocol);
-    }
     if (endpoint != null) {
       System.setProperty("otel.exporter.otlp.endpoint", endpoint);
     }
-    if (exporter != null) {
-      System.setProperty("otel.traces.exporter", exporter);
-    }
     System.setProperty("otel.service.name", "org.apache.druid");
-    log.info("Init OTel with otel.experimental.exporter.otlp.traces.protocol = " + protocol);
     log.info("Init OTel with otel.exporter.otlp.endpoint = " + endpoint);
-    log.info("Init OTel with otel.traces.exporter = " + exporter);
-    return new OpenTelemetryEmitter(GlobalOpenTelemetry.getTracer("druid-opentelemtry-extension"));
+    OpenTelemetrySdkAutoConfiguration.initialize();
+    return new OpenTelemetryEmitter(GlobalOpenTelemetry.getTracer("druid-opentelemetry-extension"));
   }
 }

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
@@ -54,6 +54,7 @@ public class OpenTelemetryEmitterModule implements DruidModule
   @Named(EMITTER_TYPE)
   public Emitter getEmitter(OpenTelemetryEmitterConfig config, ObjectMapper mapper)
   {
+    // It's a good practice to not set the GlobalOpenTelemetry since there's no need to do that
     return new OpenTelemetryEmitter(OpenTelemetrySdkAutoConfiguration.initialize(false));
   }
 }

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
@@ -54,7 +54,6 @@ public class OpenTelemetryEmitterModule implements DruidModule
   @Named(EMITTER_TYPE)
   public Emitter getEmitter(OpenTelemetryEmitterConfig config, ObjectMapper mapper)
   {
-    OpenTelemetrySdkAutoConfiguration.initialize();
-    return new OpenTelemetryEmitter();
+    return new OpenTelemetryEmitter(OpenTelemetrySdkAutoConfiguration.initialize(false));
   }
 }

--- a/extensions-contrib/opentelemetry-emitter/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/opentelemetry-emitter/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.emitter.opentelemetry.OpenTelemetryEmitterModule

--- a/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
+++ b/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
@@ -66,8 +66,10 @@ public class OpenTelemetryEmitterTest
     }
   }
 
+
+  // Check that we don't call "emitQueryTimeEvent" method for event that is not instance of ServiceMetricEvent
   @Test
-  public void testNoEmiteNotServiceMetric()
+  public void testNoEmitNotServiceMetric()
   {
     final Event notServiceMetricEvent =
         new Event()
@@ -93,8 +95,9 @@ public class OpenTelemetryEmitterTest
     EasyMock.verifyUnexpectedCalls(emitter);
   }
 
+  // Check that we don't call "emitQueryTimeEvent" method for ServiceMetricEvent that is not "query/time" type
   @Test
-  public void testNoEmiteNotQueryTimeMetric()
+  public void testNoEmitNotQueryTimeMetric()
   {
     final ServiceMetricEvent notQueryTimeMetric =
         new ServiceMetricEvent.Builder().build(

--- a/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
+++ b/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.emitter.opentelemetry;
+
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.easymock.EasyMock;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OpenTelemetryEmitterTest
+{
+  private static class NoopExporter implements SpanExporter
+  {
+    public Collection<SpanData> spanData;
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> collection)
+    {
+      this.spanData = collection;
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush()
+    {
+      return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown()
+    {
+      return CompletableResultCode.ofSuccess();
+    }
+  }
+
+  @Test
+  public void testNoEmiteNotServiceMetric()
+  {
+    final Event notServiceMetricEvent =
+        new Event()
+        {
+          @Override
+          public Map<String, Object> toMap()
+          {
+            return null;
+          }
+
+          @Override
+          public String getFeed()
+          {
+            return null;
+          }
+        };
+
+    OpenTelemetryEmitter emitter = EasyMock.createMock(OpenTelemetryEmitter.class);
+    emitter.emit(notServiceMetricEvent);
+    EasyMock.replay(emitter);
+
+    emitter.emit(notServiceMetricEvent);
+    EasyMock.verifyUnexpectedCalls(emitter);
+  }
+
+  @Test
+  public void testNoEmiteNotQueryTimeMetric()
+  {
+    final ServiceMetricEvent notQueryTimeMetric =
+        new ServiceMetricEvent.Builder().build(
+                                            DateTimes.nowUtc(),
+                                            "query/cache/total/hitRate",
+                                            0.54
+                                        )
+                                        .build(
+                                            "broker",
+                                            "brokerHost1"
+                                        );
+
+    OpenTelemetryEmitter emitter = EasyMock.createMock(OpenTelemetryEmitter.class);
+    emitter.emit(notQueryTimeMetric);
+    EasyMock.replay(emitter);
+
+    emitter.emit(notQueryTimeMetric);
+    EasyMock.verifyUnexpectedCalls(emitter);
+  }
+
+  @Test
+  public void testTraceparentId()
+  {
+    final String traceId = "00-54ef39243e3feb12072e0f8a74c1d55a-ad6d5b581d7c29c1-01";
+    final String expectedParentTraceId = "54ef39243e3feb12072e0f8a74c1d55a";
+    final String expectedParentSpanId = "ad6d5b581d7c29c1";
+    final Map<String, String> context = new HashMap<>();
+    context.put("traceparent", traceId);
+
+    final String serviceName = "druid/broker";
+    final DateTime createdTime = DateTimes.nowUtc();
+    final long metricValue = 100;
+
+    NoopExporter noopExporter = new NoopExporter();
+    SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                                                        .addSpanProcessor(SimpleSpanProcessor.create(noopExporter))
+                                                        .build();
+
+    final ServiceMetricEvent queryTimeMetric =
+        new ServiceMetricEvent.Builder().setDimension("context", context)
+                                        .build(
+                                            createdTime,
+                                            "query/time",
+                                            metricValue
+                                        )
+                                        .build(
+                                            serviceName,
+                                            "host"
+                                        );
+    Tracer tracer = OpenTelemetrySdk.builder()
+                                    .setTracerProvider(tracerProvider)
+                                    .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                                    .buildAndRegisterGlobal().getTracer("test", "v1");
+
+    OpenTelemetryEmitter emitter = new OpenTelemetryEmitter(tracer);
+    emitter.emit(queryTimeMetric);
+
+    Assert.assertEquals(1, noopExporter.spanData.size());
+
+    SpanData actualSpanData = noopExporter.spanData.iterator().next();
+    Assert.assertEquals(serviceName, actualSpanData.getName());
+    Assert.assertEquals((createdTime.getMillis() - metricValue) * 1_000_000, actualSpanData.getStartEpochNanos());
+    Assert.assertEquals(expectedParentTraceId, actualSpanData.getParentSpanContext().getTraceId());
+    Assert.assertEquals(expectedParentSpanId, actualSpanData.getParentSpanContext().getSpanId());
+  }
+}

--- a/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
+++ b/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.emitter.opentelemetry;
 
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -147,12 +146,12 @@ public class OpenTelemetryEmitterTest
                                             serviceName,
                                             "host"
                                         );
-    Tracer tracer = OpenTelemetrySdk.builder()
-                                    .setTracerProvider(tracerProvider)
-                                    .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
-                                    .buildAndRegisterGlobal().getTracer("test", "v1");
+    OpenTelemetrySdk.builder()
+                    .setTracerProvider(tracerProvider)
+                    .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                    .buildAndRegisterGlobal();
 
-    OpenTelemetryEmitter emitter = new OpenTelemetryEmitter(tracer);
+    OpenTelemetryEmitter emitter = new OpenTelemetryEmitter();
     emitter.emit(queryTimeMetric);
 
     Assert.assertEquals(1, noopExporter.spanData.size());

--- a/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
+++ b/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.emitter.opentelemetry;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -30,25 +31,26 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
-import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
 
 public class OpenTelemetryEmitterTest
 {
   private static class NoopExporter implements SpanExporter
   {
-    public Collection<SpanData> spanData;
+    public Collection<SpanData> spanDataCollection;
 
     @Override
     public CompletableResultCode export(Collection<SpanData> collection)
     {
-      this.spanData = collection;
+      this.spanDataCollection = collection;
       return CompletableResultCode.ofSuccess();
     }
 
@@ -65,6 +67,21 @@ public class OpenTelemetryEmitterTest
     }
   }
 
+  private OpenTelemetry openTelemetry;
+  private NoopExporter noopExporter;
+
+  @Before
+  public void setup()
+  {
+    noopExporter = new NoopExporter();
+    openTelemetry = OpenTelemetrySdk.builder()
+                                    .setTracerProvider(SdkTracerProvider.builder()
+                                                                        .addSpanProcessor(SimpleSpanProcessor.create(
+                                                                            noopExporter))
+                                                                        .build())
+                                    .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                                    .build();
+  }
 
   // Check that we don't call "emitQueryTimeEvent" method for event that is not instance of ServiceMetricEvent
   @Test
@@ -76,7 +93,7 @@ public class OpenTelemetryEmitterTest
           @Override
           public Map<String, Object> toMap()
           {
-            return null;
+            return Collections.emptyMap();
           }
 
           @Override
@@ -86,12 +103,9 @@ public class OpenTelemetryEmitterTest
           }
         };
 
-    OpenTelemetryEmitter emitter = EasyMock.createMock(OpenTelemetryEmitter.class);
+    OpenTelemetryEmitter emitter = new OpenTelemetryEmitter(openTelemetry);
     emitter.emit(notServiceMetricEvent);
-    EasyMock.replay(emitter);
-
-    emitter.emit(notServiceMetricEvent);
-    EasyMock.verifyUnexpectedCalls(emitter);
+    Assert.assertNull(noopExporter.spanDataCollection);
   }
 
   // Check that we don't call "emitQueryTimeEvent" method for ServiceMetricEvent that is not "query/time" type
@@ -109,12 +123,9 @@ public class OpenTelemetryEmitterTest
                                             "brokerHost1"
                                         );
 
-    OpenTelemetryEmitter emitter = EasyMock.createMock(OpenTelemetryEmitter.class);
+    OpenTelemetryEmitter emitter = new OpenTelemetryEmitter(openTelemetry);
     emitter.emit(notQueryTimeMetric);
-    EasyMock.replay(emitter);
-
-    emitter.emit(notQueryTimeMetric);
-    EasyMock.verifyUnexpectedCalls(emitter);
+    Assert.assertNull(noopExporter.spanDataCollection);
   }
 
   @Test
@@ -130,11 +141,6 @@ public class OpenTelemetryEmitterTest
     final DateTime createdTime = DateTimes.nowUtc();
     final long metricValue = 100;
 
-    NoopExporter noopExporter = new NoopExporter();
-    SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
-                                                        .addSpanProcessor(SimpleSpanProcessor.create(noopExporter))
-                                                        .build();
-
     final ServiceMetricEvent queryTimeMetric =
         new ServiceMetricEvent.Builder().setDimension("context", context)
                                         .build(
@@ -146,17 +152,13 @@ public class OpenTelemetryEmitterTest
                                             serviceName,
                                             "host"
                                         );
-    OpenTelemetrySdk.builder()
-                    .setTracerProvider(tracerProvider)
-                    .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
-                    .buildAndRegisterGlobal();
 
-    OpenTelemetryEmitter emitter = new OpenTelemetryEmitter();
+    OpenTelemetryEmitter emitter = new OpenTelemetryEmitter(openTelemetry);
     emitter.emit(queryTimeMetric);
 
-    Assert.assertEquals(1, noopExporter.spanData.size());
+    Assert.assertEquals(1, noopExporter.spanDataCollection.size());
 
-    SpanData actualSpanData = noopExporter.spanData.iterator().next();
+    SpanData actualSpanData = noopExporter.spanDataCollection.iterator().next();
     Assert.assertEquals(serviceName, actualSpanData.getName());
     Assert.assertEquals((createdTime.getMillis() - metricValue) * 1_000_000, actualSpanData.getStartEpochNanos());
     Assert.assertEquals(expectedParentTraceId, actualSpanData.getParentSpanContext().getTraceId());

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,7 @@
         <module>extensions-contrib/aliyun-oss-extensions</module>
         <module>extensions-contrib/opencensus-extensions</module>
         <module>extensions-contrib/confluent-extensions</module>
+        <module>extensions-contrib/opentelemetry-emitter</module>
         <!-- distribution packaging -->
         <module>distribution</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -1659,7 +1659,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>3.2.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Description

OpenTelemetry extension for distributed traces.
Use Druid emitter functionality to ingest metrics and create spans from `query/time` metrics. [More about emitter](https://druid.apache.org/docs/latest/configuration/index.html#emitting-metrics)
Use `context` field for propagation. [More about context field](https://druid.apache.org/docs/latest/querying/sql.html#http-post)
![image](https://user-images.githubusercontent.com/21279722/134135686-37e8987a-ad71-4ffa-9514-50b902c34fac.png)
![image](https://user-images.githubusercontent.com/21279722/134135726-078c04f5-f02f-4bb2-8998-017eb97dcc3b.png)


##### Key changed/added classes in this PR
 * Add opentelemetry extension
 * Add readme about how to test it locally
 * Add tests for opentelemetry emitter