### PR TITLE
Handling review comments - https://github.com/apache/druid/pull/11630#pullrequestreview-760351816

### DIFF
--- a/docs/development/extensions-core/kafka-ingestion.md
+++ b/docs/development/extensions-core/kafka-ingestion.md
@@ -167,7 +167,7 @@ but unfortunately, it doesn't support all data formats supported by the legacy `
 (They will be supported in the future.)
 
 The supported `inputFormat`s include [`csv`](../../ingestion/data-formats.md#csv),
-[`delimited`](../../ingestion/data-formats.md#tsv-delimited), and [`json`](../../ingestion/data-formats.md#json).
+[`delimited`](../../ingestion/data-formats.md#tsv-delimited), [`json`](../../ingestion/data-formats.md#json) and [`kafka`](../../ingestion/data-formats.md#kafka).
 You can also read [`avro_stream`](../../ingestion/data-formats.md#avro-stream-parser),
 [`protobuf`](../../ingestion/data-formats.md#protobuf-parser),
 and [`thrift`](../extensions-contrib/thrift.md) formats using `parser`.

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -152,6 +152,51 @@ The `inputFormat` to load data of a delimited format. An example is:
 
 Be sure to change the `delimiter` to the appropriate delimiter for your data. Like CSV, you must specify the columns and which subset of the columns you want indexed.
 
+### KAFKA
+
+The `inputFormat` to load complete kafka record including header, key and value. An example is:
+
+```json
+"ioConfig": {
+  "inputFormat": {
+      "type": "kafka",
+      "headerLabelPrefix": "kafka.header.",
+      "timestampColumnName": "kafka.timestamp",
+      "keyColumnName": "kafka.key",
+      "headerFormat":
+      {
+        "type": "string"
+      },
+      "keyFormat":
+      {
+        "type": "json"
+      },
+      "valueFormat":
+      {
+        "type": "json"
+      }
+  },
+  ...
+}
+```
+
+The KAFKA `inputFormat` has the following components:
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| type | String | This should say `kafka`. | yes |
+| headerLabelPrefix | String | A custom label prefix for all the header columns. | no (default = "kafka.header.") |
+| timestampColumnName | String | Specifies the name of the column for the kafka record's timestamp.| no (default = "kafka.timestamp") |
+| keyColumnName | String | Specifies the name of the column for the kafka record's key.| no (default = "kafka.key") |
+| headerFormat | Object | headerFormat specifies how to parse the kafka headers. Current supported type is "string". | no |
+| keyFormat | Object | keyFormat can be any existing inputFormat to parse the kafka key. See [the below section](../development/extensions-core/kafka-ingestion.md#specifying-data-format) for details about specifying the input format. | no |
+| valueFormat | Object | valueFormat can be any existing inputFormat to parse the kafka value payload. See [the below section](../development/extensions-core/kafka-ingestion.md#specifying-data-format) for details about specifying the input format. | yes |
+
+```
+> For any conflicts in dimension/metric names, this inputFormat will prefer kafka value's column names.
+> This will enable seemless porting of existing kafka ingestion inputFormat to this new format, with additional columns from kafka header and key.
+```
+
 ### ORC
 
 > You need to include the [`druid-orc-extensions`](../development/extensions-core/orc.md) as an extension to use the ORC input format.

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
@@ -37,10 +37,8 @@ import java.util.Objects;
 public class KafkaInputFormat implements InputFormat
 {
   private static final String DEFAULT_HEADER_COLUMN_PREFIX = "kafka.header.";
-  private static final String DEFAULT_TIMESTAMP_COLUMN_PREFIX = "kafka.";
-  private static final String DEFAULT_KEY_COLUMN_PREFIX = "kafka.";
-  private static final String DEFAULT_TIMESTAMP_STRING = "timestamp";
-  private static final String DEFAULT_KEY_STRING = "key";
+  private static final String DEFAULT_TIMESTAMP_COLUMN_NAME = "kafka.timestamp";
+  private static final String DEFAULT_KEY_COLUMN_NAME = "kafka.key";
   public static final String DEFAULT_AUTO_TIMESTAMP_STRING = "__kif_auto_timestamp";
 
   // Since KafkaInputFormat blends data from header, key and payload, timestamp spec can be pointing to an attribute within one of these
@@ -52,24 +50,24 @@ public class KafkaInputFormat implements InputFormat
   private final InputFormat valueFormat;
   private final InputFormat keyFormat;
   private final String headerColumnPrefix;
-  private final String keyColumnPrefix;
-  private final String recordTimestampColumnPrefix;
+  private final String keyColumnName;
+  private final String timestampColumnName;
 
   public KafkaInputFormat(
       @JsonProperty("headerFormat") @Nullable KafkaHeaderFormat headerFormat,
       @JsonProperty("keyFormat") @Nullable InputFormat keyFormat,
       @JsonProperty("valueFormat") InputFormat valueFormat,
       @JsonProperty("headerColumnPrefix") @Nullable String headerColumnPrefix,
-      @JsonProperty("keyColumnPrefix") @Nullable String keyColumnPrefix,
-      @JsonProperty("recordTimestampColumnPrefix") @Nullable String recordTimestampColumnPrefix
+      @JsonProperty("keyColumnName") @Nullable String keyColumnName,
+      @JsonProperty("timestampColumnName") @Nullable String timestampColumnName
   )
   {
     this.headerFormat = headerFormat;
     this.keyFormat = keyFormat;
     this.valueFormat = Preconditions.checkNotNull(valueFormat, "valueFormat must not be null");
     this.headerColumnPrefix = headerColumnPrefix != null ? headerColumnPrefix : DEFAULT_HEADER_COLUMN_PREFIX;
-    this.keyColumnPrefix = keyColumnPrefix != null ? keyColumnPrefix : DEFAULT_KEY_COLUMN_PREFIX;
-    this.recordTimestampColumnPrefix = recordTimestampColumnPrefix != null ? recordTimestampColumnPrefix : DEFAULT_TIMESTAMP_COLUMN_PREFIX;
+    this.keyColumnName = keyColumnName != null ? keyColumnName : DEFAULT_KEY_COLUMN_NAME;
+    this.timestampColumnName = timestampColumnName != null ? timestampColumnName : DEFAULT_TIMESTAMP_COLUMN_NAME;
   }
 
   @Override
@@ -103,8 +101,8 @@ public class KafkaInputFormat implements InputFormat
                   source,
                   temporaryDirectory
           ),
-        keyColumnPrefix + DEFAULT_KEY_STRING,
-        recordTimestampColumnPrefix + DEFAULT_TIMESTAMP_STRING
+        keyColumnName,
+        timestampColumnName
     );
   }
 
@@ -133,15 +131,15 @@ public class KafkaInputFormat implements InputFormat
   }
 
   @JsonProperty
-  public String getKeyColumnPrefix()
+  public String getKeyColumnName()
   {
-    return keyColumnPrefix;
+    return keyColumnName;
   }
 
   @JsonProperty
-  public String getRecordTimestampColumnPrefix()
+  public String getTimestampColumnName()
   {
-    return recordTimestampColumnPrefix;
+    return timestampColumnName;
   }
 
   @Override
@@ -158,15 +156,15 @@ public class KafkaInputFormat implements InputFormat
            && Objects.equals(valueFormat, that.valueFormat)
            && Objects.equals(keyFormat, that.keyFormat)
            && Objects.equals(headerColumnPrefix, that.headerColumnPrefix)
-           && Objects.equals(keyColumnPrefix, that.keyColumnPrefix)
-           && Objects.equals(recordTimestampColumnPrefix, that.recordTimestampColumnPrefix);
+           && Objects.equals(keyColumnName, that.keyColumnName)
+           && Objects.equals(timestampColumnName, that.timestampColumnName);
   }
 
   @Override
   public int hashCode()
   {
     return Objects.hash(headerFormat, valueFormat, keyFormat,
-                        headerColumnPrefix, keyColumnPrefix, recordTimestampColumnPrefix
+                        headerColumnPrefix, keyColumnName, timestampColumnName
     );
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -102,7 +102,7 @@ public class KafkaInputFormatTest
             ),
             null, null, false //make sure JsonReader is used
         ),
-        "kafka.newheader.", "kafka.newkey.", "kafka.newts."
+        "kafka.newheader.", "kafka.newkey.key", "kafka.newts.timestamp"
     );
   }
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -53,6 +53,8 @@ import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.druid.data.input.kafkainput.KafkaInputFormat;
+import org.apache.druid.data.input.kafkainput.KafkaStringHeaderFormat;
 import org.apache.druid.discovery.DataNodeService;
 import org.apache.druid.discovery.DruidNodeAnnouncer;
 import org.apache.druid.discovery.LookupNodeService;
@@ -200,6 +202,12 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       return "application/json".getBytes(StandardCharsets.UTF_8);
     }
   });
+  private static final InputFormat KAFKA_INPUT_FORMAT = new KafkaInputFormat(
+      new KafkaStringHeaderFormat(null),
+      INPUT_FORMAT,
+      INPUT_FORMAT,
+      "kafka.testheader.", "kafka.key", "kafka.timestamp"
+  );
 
   private static TestingCluster zkServer;
   private static TestBroker kafkaServer;
@@ -1228,6 +1236,84 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       Assert.assertEquals((long) i++, event.get("kafka.offset"));
       Assert.assertEquals(topic, event.get("kafka.topic"));
       Assert.assertEquals("application/json", event.get("kafka.header.encoding"));
+    }
+    // insert remaining data
+    insertData(Iterables.skip(records, 3));
+
+    // Wait for task to exit
+    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+
+    // Check metrics
+    Assert.assertEquals(4, task.getRunner().getRowIngestionMeters().getProcessed());
+    Assert.assertEquals(0, task.getRunner().getRowIngestionMeters().getUnparseable());
+    Assert.assertEquals(0, task.getRunner().getRowIngestionMeters().getThrownAway());
+  }
+
+  @Test(timeout = 60_000L)
+  public void testKafkaInputFormat() throws Exception
+  {
+    // Insert data
+    insertData(Iterables.limit(records, 3));
+
+    final KafkaIndexTask task = createTask(
+        null,
+        new DataSchema(
+            "test_ds",
+            new TimestampSpec("timestamp", "iso", null),
+            new DimensionsSpec(
+                Arrays.asList(
+                    new StringDimensionSchema("dim1"),
+                    new StringDimensionSchema("dim1t"),
+                    new StringDimensionSchema("dim2"),
+                    new LongDimensionSchema("dimLong"),
+                    new FloatDimensionSchema("dimFloat"),
+                    new StringDimensionSchema("kafka.testheader.encoding")
+                ),
+                null,
+                null
+            ),
+            new AggregatorFactory[]{
+                new DoubleSumAggregatorFactory("met1sum", "met1"),
+                new CountAggregatorFactory("rows")
+            },
+            new UniformGranularitySpec(Granularities.DAY, Granularities.NONE, null),
+            null
+        ),
+        new KafkaIndexTaskIOConfig(
+            0,
+            "sequence0",
+            new SeekableStreamStartSequenceNumbers<>(topic, ImmutableMap.of(0, 0L), ImmutableSet.of()),
+            new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(0, 5L)),
+            kafkaServer.consumerProperties(),
+            KafkaSupervisorIOConfig.DEFAULT_POLL_TIMEOUT_MILLIS,
+            true,
+            null,
+            null,
+            KAFKA_INPUT_FORMAT
+        )
+    );
+    Assert.assertTrue(task.supportsQueries());
+
+    final ListenableFuture<TaskStatus> future = runTask(task);
+
+    while (countEvents(task) != 3) {
+      Thread.sleep(25);
+    }
+
+    Assert.assertEquals(Status.READING, task.getRunner().getStatus());
+
+    final QuerySegmentSpec interval = OBJECT_MAPPER.readValue(
+        "\"2008/2012\"", QuerySegmentSpec.class
+    );
+    List<ScanResultValue> scanResultValues = scanData(task, interval);
+    //verify that there are no records indexed in the rollbacked time period
+    Assert.assertEquals(3, Iterables.size(scanResultValues));
+
+    int i = 0;
+    for (ScanResultValue result : scanResultValues) {
+      final Map<String, Object> event = ((List<Map<String, Object>>) result.getEvents()).get(0);
+      Assert.assertEquals("application/json", event.get("kafka.testheader.encoding"));
+      Assert.assertEquals("y", event.get("dim2"));
     }
     // insert remaining data
     insertData(Iterables.skip(records, 3));


### PR DESCRIPTION
Allowing complete column names for kafka record's timestamp and key.

Adding an end to end test case for kafka input format.

Updating the docs to reflect the new input format, with example and explanation.