### PR TITLE
Creating an index based on druid_segments(datasource, used, start, end)

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -283,6 +283,11 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
                 "CREATE INDEX idx_%1$s_datasource_used_end ON %1$s(dataSource, used, %2$send%2$s)",
                 tableName,
                 getQuoteString()
+            ),
+            StringUtils.format(
+                "CREATE INDEX idx_%1$s_datasource_used_start_end ON %1$s(dataSource, used, start, %2$send%2$s)",
+                tableName,
+                getQuoteString()
             )
         )
     );


### PR DESCRIPTION
This index helps in faster query results during kill task's query on interval based unused segment listing. This had become a bottleneck at our production loads causing coordinator to wait longer for metadata db replies and hence causing increased ingestion lag. The new index helps reduce the time taken to fetch this list avoiding any incidents.