### PR TITLE
[backport] prefer string concatenation over String.format in performance sensitive code (#10997)

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/NettyHttpClient.java
@@ -113,7 +113,7 @@ public class NettyHttpClient extends AbstractHttpClient
     final URL url = request.getUrl();
     final Multimap<String, String> headers = request.getHeaders();
 
-    final String requestDesc = StringUtils.format("%s %s", method, url);
+    final String requestDesc = method + " " + url;
     if (log.isDebugEnabled()) {
       log.debug("[%s] starting", requestDesc);
     }
@@ -422,13 +422,12 @@ public class NettyHttpClient extends AbstractHttpClient
       }
     }
 
-    return StringUtils.format("%s:%s", url.getHost(), port);
+    return url.getHost() + ":" + port;
   }
 
   private String getPoolKey(URL url)
   {
-    return StringUtils.format(
-        "%s://%s:%s", url.getProtocol(), url.getHost(), url.getPort() == -1 ? url.getDefaultPort() : url.getPort()
-    );
+    return url.getProtocol() + "://" + url.getHost() + ":"
+           + (url.getPort() == -1 ? url.getDefaultPort() : url.getPort());
   }
 }

--- a/core/src/main/java/org/apache/druid/java/util/http/client/Request.java
+++ b/core/src/main/java/org/apache/druid/java/util/http/client/Request.java
@@ -22,7 +22,6 @@ package org.apache.druid.java.util.http.client;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-import org.apache.druid.java.util.common.StringUtils;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBufferFactory;
 import org.jboss.netty.buffer.HeapChannelBufferFactory;
@@ -165,8 +164,8 @@ public class Request
 
   public Request setBasicAuthentication(String username, String password)
   {
-    final String base64Value = base64Encode(StringUtils.format("%s:%s", username, password));
-    setHeader(HttpHeaders.Names.AUTHORIZATION, StringUtils.format("Basic %s", base64Value));
+    final String base64Value = base64Encode(username + ":" + password);
+    setHeader(HttpHeaders.Names.AUTHORIZATION, "Basic " + base64Value);
     return this;
   }
 

--- a/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
@@ -20,7 +20,6 @@
 package org.apache.druid.query.spec;
 
 import com.google.common.base.Supplier;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Accumulator;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.SequenceWrapper;
@@ -69,7 +68,7 @@ public class SpecificSegmentQueryRunner<T> implements QueryRunner<T>
 
     final Thread currThread = Thread.currentThread();
     final String currThreadName = currThread.getName();
-    final String newName = StringUtils.format("%s_%s_%s", query.getType(), query.getDataSource(), query.getIntervals());
+    final String newName = query.getType() + "_" + query.getDataSource() + "_" + query.getIntervals();
 
     final Sequence<T> baseSequence = doNamed(
         currThread,

--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -159,8 +159,8 @@ public class DirectDruidClient<T> implements QueryRunner<T>
     final JavaType queryResultType = isBySegment ? toolChest.getBySegmentResultType() : toolChest.getBaseResultType();
 
     final ListenableFuture<InputStream> future;
-    final String url = StringUtils.format("%s://%s/druid/v2/", scheme, host);
-    final String cancelUrl = StringUtils.format("%s://%s/druid/v2/%s", scheme, host, query.getId());
+    final String url = scheme + "://" + host + "/druid/v2/";
+    final String cancelUrl = url + query.getId();
 
     try {
       log.debug("Querying queryId[%s] url[%s]", query.getId(), url);

--- a/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -32,7 +32,6 @@ import org.apache.druid.guice.annotations.Smile;
 import org.apache.druid.guice.http.DruidHttpClientConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
@@ -376,7 +375,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
   static String makeURI(String scheme, String host, String requestURI, String rawQueryString)
   {
     return JettyUtils.concatenateForRewrite(
-        StringUtils.format("%s://%s", scheme, host),
+        scheme + "://" + host,
         requestURI,
         rawQueryString
     );


### PR DESCRIPTION
String.format relies on regex parsing, which makes these calls expensive
at higher request volumes.
