### PR TITLE
Add attribute to exclude druid spans from kafka exporter

### DIFF
--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
@@ -46,11 +46,13 @@ public class OpenTelemetryEmitter implements Emitter
   private static final Logger log = new Logger(OpenTelemetryEmitter.class);
   private final Tracer tracer;
   private final TextMapPropagator propagator;
+  private final OpenTelemetryEmitterConfig config;
 
-  OpenTelemetryEmitter(OpenTelemetry openTelemetry)
+  OpenTelemetryEmitter(OpenTelemetry openTelemetry, OpenTelemetryEmitterConfig config)
   {
     tracer = openTelemetry.getTracer("druid-opentelemetry-extension");
     propagator = openTelemetry.getPropagators().getTextMapPropagator();
+    this.config = config;
   }
 
   @Override
@@ -94,7 +96,8 @@ public class OpenTelemetryEmitter implements Emitter
                        .filter(entry -> !TRACEPARENT_PROPAGATION_FIELDS.contains(entry.getKey()))
                        .forEach(entry -> span.setAttribute(entry.getKey(), entry.getValue().toString()));
 
-      span.setAttribute("exporter.kafka", "exclude");
+      config.getDefaultAttributes().forEach((key, value) -> span.setAttribute(key, value.toString()));
+
       Object status = event.getUserDims().get("success");
       if (status == null) {
         span.setStatus(StatusCode.UNSET);

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
@@ -96,7 +96,7 @@ public class OpenTelemetryEmitter implements Emitter
                        .filter(entry -> !TRACEPARENT_PROPAGATION_FIELDS.contains(entry.getKey()))
                        .forEach(entry -> span.setAttribute(entry.getKey(), entry.getValue().toString()));
 
-      config.getDefaultAttributes().forEach((key, value) -> span.setAttribute(key, value.toString()));
+      config.getDefaultAttributes().forEach((key, value) -> span.setAttribute(key, value));
 
       Object status = event.getUserDims().get("success");
       if (status == null) {

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitter.java
@@ -94,6 +94,7 @@ public class OpenTelemetryEmitter implements Emitter
                        .filter(entry -> !TRACEPARENT_PROPAGATION_FIELDS.contains(entry.getKey()))
                        .forEach(entry -> span.setAttribute(entry.getKey(), entry.getValue().toString()));
 
+      span.setAttribute("exporter.kafka", "exclude");
       Object status = event.getUserDims().get("success");
       if (status == null) {
         span.setStatus(StatusCode.UNSET);

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
@@ -22,6 +22,7 @@ package org.apache.druid.emitter.opentelemetry;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.Map;
 
@@ -31,6 +32,7 @@ import java.util.Map;
 public class OpenTelemetryEmitterConfig
 {
   @JsonProperty
+  @NotNull
   private final Map<String, String> defaultAttributes;
 
   @JsonCreator

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterConfig.java
@@ -19,9 +19,28 @@
 
 package org.apache.druid.emitter.opentelemetry;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.Map;
+
 /**
- * The placeholder for future configurations but there is no configuration yet
+ * The placeholder for configurations
  */
 public class OpenTelemetryEmitterConfig
 {
+  @JsonProperty
+  private final Map<String, String> defaultAttributes;
+
+  @JsonCreator
+  public OpenTelemetryEmitterConfig(@JsonProperty("defaultAttributes") Map<String, String> defaultAttributes)
+  {
+    this.defaultAttributes = defaultAttributes != null ? defaultAttributes : Collections.emptyMap();
+  }
+
+  public Map<String, String> getDefaultAttributes()
+  {
+    return defaultAttributes;
+  }
 }

--- a/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
+++ b/extensions-contrib/opentelemetry-emitter/src/main/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterModule.java
@@ -55,6 +55,6 @@ public class OpenTelemetryEmitterModule implements DruidModule
   public Emitter getEmitter(OpenTelemetryEmitterConfig config, ObjectMapper mapper)
   {
     // It's a good practice to not set the GlobalOpenTelemetry since there's no need to do that
-    return new OpenTelemetryEmitter(OpenTelemetrySdkAutoConfiguration.initialize(false));
+    return new OpenTelemetryEmitter(OpenTelemetrySdkAutoConfiguration.initialize(false), config);
   }
 }

--- a/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
+++ b/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
@@ -70,6 +70,7 @@ public class OpenTelemetryEmitterTest
     }
   }
   private static final DateTime TIMESTAMP = DateTimes.of(2021, 11, 5, 1, 1);
+  private static int DEFAULT_ATTRIBUTES_SIZE = 1;
 
   private OpenTelemetry openTelemetry;
   private NoopExporter noopExporter;
@@ -191,7 +192,7 @@ public class OpenTelemetryEmitterTest
     emitter.emit(queryTimeMetricWithAttributes);
 
     SpanData actualSpanData = noopExporter.spanDataCollection.iterator().next();
-    Assert.assertEquals(1, actualSpanData.getAttributes().size());
+    Assert.assertEquals(DEFAULT_ATTRIBUTES_SIZE + 1, actualSpanData.getAttributes().size());
     Assert.assertEquals(expectedAttributeValue, actualSpanData.getAttributes().get(AttributeKey.stringKey(expectedAttributeKey)));
   }
 
@@ -216,7 +217,7 @@ public class OpenTelemetryEmitterTest
     emitter.emit(queryTimeMetric);
 
     SpanData actualSpanData = noopExporter.spanDataCollection.iterator().next();
-    Assert.assertEquals(0, actualSpanData.getAttributes().size());
+    Assert.assertEquals(DEFAULT_ATTRIBUTES_SIZE, actualSpanData.getAttributes().size());
   }
 
   @Test


### PR DESCRIPTION
### Description

We don't want to export druid spans to kafka. Added attribute to handle this case. See [link](https://github.com/confluentinc/cc-otel-collector/pull/178) for more info.