### PR TITLE
Add opentelemetry-exporter-otlp dependency

### DIFF
--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -75,6 +75,10 @@
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-context</artifactId>
     </dependency>
     <dependency>
@@ -161,6 +165,7 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <!-- Transitive dependencies from opentelemetry but explicitly added to be shadowed -->
+            <ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-otlp</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>io.grpc:grpc-netty-shaded</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>com.google.guava:guava</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>


### PR DESCRIPTION
`opentelemetry-exporter-otlp` was removed in this PR https://github.com/confluentinc/druid/pull/59, because dependency checker reported error:
```
[WARNING] Unused declared dependencies found:
[WARNING]    io.opentelemetry:opentelemetry-exporter-otlp:jar:1.7.0:compile
```
But we need this dependency at runtime, otherwise we get an error.
```
Caused by: org.apache.druid.opentelemetry.shaded.io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException: OTLP gRPC Trace Exporter enabled but opentelemetry-exporter-otlp not found on classpath. Make sure to add it as a dependency to enable this feature.
```