### PR TITLE
backport apache#12056: set log4j2.is.webapp to false if not set

### DIFF
--- a/services/src/test/java/org/apache/druid/cli/Log4JShutdownPropertyCheckerTest.java
+++ b/services/src/test/java/org/apache/druid/cli/Log4JShutdownPropertyCheckerTest.java
@@ -19,21 +19,25 @@
 
 package org.apache.druid.cli;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.util.Properties;
 
-public class Log4JShutdownPropertyChecker implements PropertyChecker
+public class Log4JShutdownPropertyCheckerTest
 {
-  @Override
-  public void checkProperties(Properties properties)
+  @Test
+  public void test_sets_the_stuff()
   {
-    if (!properties.containsKey("log4j.shutdownCallbackRegistry")) {
-      properties.setProperty("log4j.shutdownCallbackRegistry", "org.apache.druid.common.config.Log4jShutdown");
-    }
-    if (!properties.containsKey("log4j.shutdownHookEnabled")) {
-      properties.setProperty("log4j.shutdownHookEnabled", "true");
-    }
-    if (!properties.containsKey("log4j2.is.webapp")) {
-      properties.setProperty("log4j2.is.webapp", "false");
-    }
+    Log4JShutdownPropertyChecker checker = new Log4JShutdownPropertyChecker();
+    Properties properties = new Properties();
+    checker.checkProperties(properties);
+
+    Assert.assertEquals(
+        "org.apache.druid.common.config.Log4jShutdown",
+        properties.get("log4j.shutdownCallbackRegistry")
+    );
+    Assert.assertEquals("true", properties.get("log4j.shutdownHookEnabled"));
+    Assert.assertEquals("false", properties.get("log4j2.is.webapp"));
   }
 }


### PR DESCRIPTION
Backport https://github.com/apache/druid/pull/12056
This PR makes shutdown hooks work again by automatically setting this to false if it is not explicitly set in system properties (similar to the shutdown hook properties themselves). I don't think this should have any impact on Druid since we are not technically a web app, and this setting only appears to be used by a few jmx related settings.