### PR TITLE
Make the OpenTelemetry InputFormat More Flexible to Metric, Value and Attribute Types

### DIFF
--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -37,6 +37,7 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -126,7 +127,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       // TODO Support HISTOGRAM and SUMMARY metrics
       case HISTOGRAM:
       case SUMMARY: {
-        inputRows = new ArrayList<>();
+        inputRows = Collections.emptyList();
         break;
       }
       default:

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -149,10 +149,8 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
 
     if (dataPoint.hasAsInt()) {
       event.put(valueDimension, dataPoint.getAsInt());
-    } else if (dataPoint.hasAsDouble()) {
-      event.put(valueDimension, dataPoint.getAsDouble());
     } else {
-      throw new IllegalStateException("Unexpected dataPoint value type. Expected Int or Double");
+      event.put(valueDimension, dataPoint.getAsDouble());
     }
 
     event.putAll(resourceAttributes);

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -95,7 +95,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
               .getAttributesList()
               .stream()
               .collect(Collectors.toMap(kv -> resourceAttributePrefix + kv.getKey(),
-                  kv -> getStringValue(kv.getValue())));
+                  kv -> parseAnyValue(kv.getValue())));
           return resourceMetrics.getInstrumentationLibraryMetricsList()
               .stream()
               .flatMap(libraryMetrics -> libraryMetrics.getMetricsList()
@@ -157,17 +157,32 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
 
     event.putAll(resourceAttributes);
     dataPoint.getAttributesList().forEach(att -> event.put(metricAttributePrefix + att.getKey(),
-        getStringValue(att.getValue())));
+        parseAnyValue(att.getValue())));
 
     return createRow(TimeUnit.NANOSECONDS.toMillis(dataPoint.getTimeUnixNano()), event);
   }
 
-  private static String getStringValue(AnyValue value)
+  private static Object parseAnyValue(AnyValue value)
   {
-    if (value.getValueCase() == AnyValue.ValueCase.STRING_VALUE) {
-      return value.getStringValue();
+    switch (value.getValueCase()) {
+      case INT_VALUE:
+        return value.getIntValue();
+      case BOOL_VALUE:
+        return value.getBoolValue();
+      case ARRAY_VALUE:
+        return value.getArrayValue();
+      case BYTES_VALUE:
+        return value.getBytesValue();
+      case DOUBLE_VALUE:
+        return value.getDoubleValue();
+      case KVLIST_VALUE:
+        return value.getKvlistValue();
+      case STRING_VALUE:
+        return value.getStringValue();
+      default:
+        // VALUE_NOT_SET:
+        return "";
     }
-    throw new IllegalStateException("Unexpected value: " + value.getValueCase());
   }
 
   InputRow createRow(long timeUnixMilli, Map<String, Object> event)

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -124,6 +124,11 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
         break;
       }
       // TODO Support HISTOGRAM and SUMMARY metrics
+      case HISTOGRAM:
+      case SUMMARY: {
+        inputRows = new ArrayList<>();
+        break;
+      }
       default:
         throw new IllegalStateException("Unexpected value: " + metric.getDataCase());
     }

--- a/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.data.input.opencensus.protobuf.OpenCensusProtobufExtensionsModule


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes https://github.com/confluentinc/druid/pull/63

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
- Quietly ignore `histogram` and `summary` metrics in the OpenTelemetry InputFormat. Previously an exception would be thrown if a `histogram` or `summary` metric were ingested. 
- Do not throw an error if DataPoint values are `VALUE_NOT_SET`, instead use a double of value 0.
- Do not throw an error if Metric Attributes are not strings, instead parse the object based off of the `valueCase`. If `VALUE_NOT_SET`, then set to an empty string
- Create a DruidModule because the OpenTelemetryInputFormat could not be deployed as a standalone InputFormat since Druid could not discover the OpenTelemetryExtensionModule.
