### PR TITLE
Hybrid OpentelemetryMetricsProtobufReader in Opencensus-extensions

### DIFF
--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -56,6 +56,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.druid.extensions</groupId>
+      <artifactId>druid-kafka-indexing-service</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid.extensions.contrib</groupId>
+      <artifactId>druid-opentelemetry-extensions</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -59,7 +59,21 @@
       <groupId>org.apache.druid.extensions</groupId>
       <artifactId>druid-kafka-indexing-service</artifactId>
       <version>${project.parent.version}</version>
-      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${apache.kafka.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.jpountz.lz4</groupId>
+          <artifactId>lz4</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.druid.extensions.contrib</groupId>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -78,7 +78,6 @@
     <dependency>
       <groupId>io.opentelemetry.proto</groupId>
       <artifactId>opentelemetry-proto</artifactId>
-      <version>${opentelemetry.proto.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.druid.extensions.contrib</groupId>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -35,6 +35,10 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
+  <properties>
+    <opentelemetry.proto.version>0.11.0-alpha</opentelemetry.proto.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.opencensus</groupId>
@@ -74,6 +78,12 @@
           <artifactId>lz4</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.proto</groupId>
+      <artifactId>opentelemetry-proto</artifactId>
+      <version>${opentelemetry.proto.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.druid.extensions.contrib</groupId>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -35,10 +35,6 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <properties>
-    <opentelemetry.proto.version>0.11.0-alpha</opentelemetry.proto.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.opencensus</groupId>
@@ -78,12 +74,6 @@
           <artifactId>lz4</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.opentelemetry.proto</groupId>
-      <artifactId>opentelemetry-proto</artifactId>
-      <version>${opentelemetry.proto.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.druid.extensions.contrib</groupId>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -76,6 +76,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry.proto</groupId>
+      <artifactId>opentelemetry-proto</artifactId>
+      <version>${opentelemetry.proto.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid.extensions.contrib</groupId>
       <artifactId>druid-opentelemetry-extensions</artifactId>
       <version>${project.parent.version}</version>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -105,6 +105,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <scope>provided</scope>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -56,26 +56,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.druid.extensions</groupId>
-      <artifactId>druid-kafka-indexing-service</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>${apache.kafka.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.jpountz.lz4</groupId>
-          <artifactId>lz4</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>io.opentelemetry.proto</groupId>
       <artifactId>opentelemetry-proto</artifactId>
     </dependency>
@@ -83,7 +63,6 @@
       <groupId>org.apache.druid.extensions.contrib</groupId>
       <artifactId>druid-opentelemetry-extensions</artifactId>
       <version>${project.parent.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -118,6 +97,18 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid.extensions</groupId>
+      <artifactId>druid-kafka-indexing-service</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${apache.kafka.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- jmh -->

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/KafkaUtils.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/KafkaUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+
+public class KafkaUtils
+{
+  /**
+   * Creates a MethodHandle that – when invoked on a KafkaRecordEntity - returns the given header value
+   * for the underlying KafkaRecordEntity
+   *
+   * The method handle is roughly equivalent to the following function
+   *
+   * (KafkaRecordEntity input) -> {
+   *   Header h = input.getRecord().headers().lastHeader(header)
+   *   if (h != null) {
+   *     return h.value();
+   *   } else {
+   *     return null;
+   *   }
+   * }
+   *
+   * Since KafkaRecordEntity only exists in the kafka-indexing-service plugin classloader,
+   * we need to look up the relevant classes in the classloader where the InputEntity was instantiated.
+   *
+   * The handle returned by this method should be cached for the classloader it was invoked with.
+   *
+   * If the lookup fails for whatever reason, the method handle will always return null;
+   *
+   * @param classLoader the kafka-indexing-service classloader
+   * @param header the header value to look up
+   * @return a MethodHandle
+   */
+  public static MethodHandle lookupGetHeaderMethod(ClassLoader classLoader, String header)
+  {
+    try {
+      Class entityType = Class.forName("org.apache.druid.data.input.kafka.KafkaRecordEntity", true, classLoader);
+      Class recordType = Class.forName("org.apache.kafka.clients.consumer.ConsumerRecord", true, classLoader);
+      Class headersType = Class.forName("org.apache.kafka.common.header.Headers", true, classLoader);
+      Class headerType = Class.forName("org.apache.kafka.common.header.Header", true, classLoader);
+
+      final MethodHandles.Lookup lookup = MethodHandles.lookup();
+      MethodHandle nonNullTest = lookup.findStatic(Objects.class, "nonNull",
+                                                   MethodType.methodType(boolean.class, Object.class)
+      ).asType(MethodType.methodType(boolean.class, headerType));
+
+      final MethodHandle getRecordMethod = lookup.findVirtual(
+          entityType,
+          "getRecord",
+          MethodType.methodType(recordType)
+      );
+      final MethodHandle headersMethod = lookup.findVirtual(recordType, "headers", MethodType.methodType(headersType));
+      final MethodHandle lastHeaderMethod = lookup.findVirtual(
+          headersType,
+          "lastHeader",
+          MethodType.methodType(headerType, String.class)
+      );
+      final MethodHandle valueMethod = lookup.findVirtual(headerType, "value", MethodType.methodType(byte[].class));
+
+      return MethodHandles.filterReturnValue(
+          MethodHandles.filterReturnValue(
+              MethodHandles.filterReturnValue(getRecordMethod, headersMethod),
+              MethodHandles.insertArguments(lastHeaderMethod, 1, header)
+          ),
+          // return null byte array if header is not present
+          MethodHandles.guardWithTest(
+              nonNullTest,
+              valueMethod,
+              // match valueMethod signature by dropping the header instance argument
+              MethodHandles.dropArguments(MethodHandles.constant(byte[].class, null), 0, headerType)
+          )
+      );
+    }
+    catch (ReflectiveOperationException e) {
+      // if lookup fails in the classloader where the InputEntity is defined, then the source may not be
+      // the kafka-indexing-service classloader, or method signatures did not match.
+      // In that case we return a method handle always returning null
+      return noopMethodHandle();
+    }
+  }
+
+  static MethodHandle noopMethodHandle()
+  {
+    return MethodHandles.dropArguments(MethodHandles.constant(byte[].class, null), 0, InputEntity.class);
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -41,6 +41,7 @@ public class OpenCensusProtobufInputFormat implements InputFormat
   private static final String DEFAULT_RESOURCE_PREFIX = "resource.";
   private static final String DEFAULT_VALUE_DIMENSION = "value";
   private static final String VERSION_HEADER_KEY = "v";
+  private static final int OPENTELEMETRY_FORMAT_VERSION = 1;
 
   private final String metricDimension;
   private final String metricLabelPrefix;
@@ -72,7 +73,7 @@ public class OpenCensusProtobufInputFormat implements InputFormat
       if (versionHeader != null) {
         int version =
           ByteBuffer.wrap(versionHeader.value()).order(ByteOrder.LITTLE_ENDIAN).getInt();
-        if (version == 1) {
+        if (version == OPENTELEMETRY_FORMAT_VERSION) {
           return new OpenTelemetryMetricsProtobufReader(
             inputRowSchema.getDimensionsSpec(),
             kafkaInputEntity,

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -69,12 +69,12 @@ public class OpenCensusProtobufInputFormat implements InputFormat
   @Override
   public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
   {
-    try{
+    try {
       KafkaRecordEntity kafkaInputEntity = (KafkaRecordEntity) source;
       Header versionHeader = kafkaInputEntity.getRecord().headers().lastHeader(VERSION_HEADER_KEY);
       int version = 0;
       if (versionHeader != null) {
-        version =  ByteBuffer.wrap(versionHeader.value()).order(ByteOrder.LITTLE_ENDIAN).getInt();
+        version = ByteBuffer.wrap(versionHeader.value()).order(ByteOrder.LITTLE_ENDIAN).getInt();
       }
 
       if (version == 1) {
@@ -87,7 +87,8 @@ public class OpenCensusProtobufInputFormat implements InputFormat
           resourceLabelPrefix
         );
       }
-    } catch (ClassCastException e){
+    }
+    catch (ClassCastException e) {
       return new OpenCensusProtobufReader(
         inputRowSchema.getDimensionsSpec(),
         (ByteEntity) source,

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/KafkaUtilsTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/KafkaUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input;
+
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+
+public class KafkaUtilsTest
+{
+
+  private static final byte[] BYTES = ByteBuffer.allocate(Integer.BYTES).putInt(42).array();
+
+  @Test
+  public void testNoopMethodHandle() throws Throwable
+  {
+    Assert.assertNull(
+        KafkaUtils.noopMethodHandle().invoke(new ByteEntity(new byte[]{}))
+    );
+  }
+
+  @Test
+  public void testKafkaRecordEntity() throws Throwable
+  {
+    final MethodHandle handle = KafkaUtils.lookupGetHeaderMethod(KafkaUtilsTest.class.getClassLoader(), "version");
+    KafkaRecordEntity input = new KafkaRecordEntity(
+        new ConsumerRecord<>(
+            "test",
+            0,
+            0,
+            0,
+            TimestampType.CREATE_TIME,
+            -1L,
+            -1,
+            -1,
+            null,
+            new byte[]{},
+            new RecordHeaders(ImmutableList.of(new Header()
+            {
+              @Override
+              public String key()
+              {
+                return "version";
+              }
+
+              @Override
+              public byte[] value()
+              {
+                return BYTES;
+              }
+            }))
+        )
+    );
+    Assert.assertArrayEquals(BYTES, (byte[]) handle.invoke(input));
+  }
+
+  @Test(expected = ClassCastException.class)
+  public void testNonKafkaEntity() throws Throwable
+  {
+    final MethodHandle handle = KafkaUtils.lookupGetHeaderMethod(KafkaUtilsTest.class.getClassLoader(), "version");
+    handle.invoke(new ByteEntity(new byte[]{}));
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusInputFormatTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusInputFormatTest.java
@@ -29,7 +29,7 @@ public class OpenCensusInputFormatTest
   @Test
   public void testSerde() throws Exception
   {
-    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name", "descriptor.", "custom.");
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name", null, "descriptor.", "custom.");
 
     final ObjectMapper jsonMapper = new ObjectMapper();
     jsonMapper.registerModules(new OpenCensusProtobufExtensionsModule().getJacksonModules());
@@ -47,7 +47,7 @@ public class OpenCensusInputFormatTest
   @Test
   public void testDefaults()
   {
-    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat(null, null, null);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat(null, null, null, null);
 
     Assert.assertEquals("name", inputFormat.getMetricDimension());
     Assert.assertEquals("", inputFormat.getMetricLabelPrefix());

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -44,7 +44,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -87,7 +88,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
   public static final long OFFSET = 13095752723L;
   public static final long TS = 1643974867555L;
   public static final TimestampType TSTYPE = TimestampType.CREATE_TIME;
-  private static final Header HEADERV1 = new RecordHeader("v", "01".getBytes(StandardCharsets.UTF_8));
+  public static final byte[] V0_HEADER_BYTES = ByteBuffer.allocate(Integer.BYTES)
+    .order(ByteOrder.LITTLE_ENDIAN)
+    .putInt(1)
+    .array();
+  private static final Header HEADERV1 = new RecordHeader("v", V0_HEADER_BYTES);
   private static final Headers HEADERS = new RecordHeaders(new Header[]{HEADERV1});
 
 

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opencensus.protobuf;
+
+import com.google.common.collect.ImmutableList;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class OpenTelemetryMetricsProtobufReaderTest
+{
+  private static final long TIMESTAMP = TimeUnit.MILLISECONDS.toNanos(Instant.parse("2019-07-12T09:30:01.123Z").toEpochMilli());
+  public static final String RESOURCE_ATTRIBUTE_COUNTRY = "country";
+  public static final String RESOURCE_ATTRIBUTE_VALUE_USA = "usa";
+
+  public static final String RESOURCE_ATTRIBUTE_ENV = "env";
+  public static final String RESOURCE_ATTRIBUTE_VALUE_DEVEL = "devel";
+
+  public static final String INSTRUMENTATION_LIBRARY_NAME = "mock-instr-lib";
+  public static final String INSTRUMENTATION_LIBRARY_VERSION = "1.0";
+
+  public static final String METRIC_ATTRIBUTE_COLOR = "color";
+  public static final String METRIC_ATTRIBUTE_VALUE_RED = "red";
+
+  public static final String METRIC_ATTRIBUTE_FOO_KEY = "foo_key";
+  public static final String METRIC_ATTRIBUTE_FOO_VAL = "foo_value";
+
+  private final MetricsData.Builder metricsDataBuilder = MetricsData.newBuilder();
+
+  private final Metric.Builder metricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
+      .addInstrumentationLibraryMetricsBuilder()
+      .addMetricsBuilder();
+
+  private final DimensionsSpec dimensionsSpec = new DimensionsSpec(ImmutableList.of(
+      new StringDimensionSchema("descriptor." + METRIC_ATTRIBUTE_COLOR),
+      new StringDimensionSchema("descriptor." + METRIC_ATTRIBUTE_FOO_KEY),
+      new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_ENV),
+      new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_COUNTRY)
+  ), null, null);
+
+  public static final String TOPIC = "telemetry.metrics.otel";
+  public static final int PARTITION = 2;
+  public static final long OFFSET = 13095752723L;
+  public static final long TS = 1643974867555L;
+  public static final TimestampType TSTYPE = TimestampType.CREATE_TIME;
+  private static final Header HEADERV1 = new RecordHeader("v", "01".getBytes(StandardCharsets.UTF_8));
+  private static final Headers HEADERS = new RecordHeaders(new Header[]{HEADERV1});
+
+
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setUp()
+  {
+    metricsDataBuilder
+        .getResourceMetricsBuilder(0)
+        .getResourceBuilder()
+        .addAttributes(KeyValue.newBuilder()
+          .setKey(RESOURCE_ATTRIBUTE_COUNTRY)
+          .setValue(AnyValue.newBuilder().setStringValue(RESOURCE_ATTRIBUTE_VALUE_USA)));
+
+    metricsDataBuilder
+      .getResourceMetricsBuilder(0)
+      .getInstrumentationLibraryMetricsBuilder(0)
+      .getInstrumentationLibraryBuilder()
+      .setName(INSTRUMENTATION_LIBRARY_NAME)
+      .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+
+  }
+
+  @Test
+  public void testSumWithAttributes() throws IOException
+  {
+    metricBuilder
+      .setName("example_sum")
+      .getSumBuilder()
+      .addDataPointsBuilder()
+      .setAsInt(6)
+      .setTimeUnixNano(TIMESTAMP)
+      .addAttributesBuilder() // test sum with attributes
+      .setKey(METRIC_ATTRIBUTE_COLOR)
+      .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
+
+    MetricsData metricsData = metricsDataBuilder.build();
+    ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,
+         -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
+    KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        "descriptor.",
+        "custom.");
+
+    CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
+        new TimestampSpec("timestamp", "iso", null),
+        dimensionsSpec,
+        Collections.emptyList()
+      ), kafkaRecordEntity, null).read();
+
+    List<InputRow> rowList = new ArrayList<>();
+    rows.forEachRemaining(rowList::add);
+    Assert.assertEquals(1, rowList.size());
+
+    InputRow row = rowList.get(0);
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_sum");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+    assertDimensionEquals(row, "value", "6");
+  }
+
+  @Test
+  public void testGaugeWithAttributes() throws IOException
+  {
+    metricBuilder.setName("example_gauge")
+      .getGaugeBuilder()
+      .addDataPointsBuilder()
+      .setAsInt(6)
+      .setTimeUnixNano(TIMESTAMP)
+      .addAttributesBuilder() // test sum with attributes
+      .setKey(METRIC_ATTRIBUTE_COLOR)
+      .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
+
+    MetricsData metricsData = metricsDataBuilder.build();
+    ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,
+        -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
+    KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        "descriptor.",
+        "custom.");
+    CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
+        new TimestampSpec("timestamp", "iso", null),
+        dimensionsSpec,
+        Collections.emptyList()
+    ), kafkaRecordEntity, null).read();
+
+    Assert.assertTrue(rows.hasNext());
+    InputRow row = rows.next();
+
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_gauge");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+    assertDimensionEquals(row, "value", "6");
+  }
+
+  @Test
+  public void testBatchedMetricParse() throws IOException
+  {
+    metricBuilder.setName("example_sum")
+      .getSumBuilder()
+      .addDataPointsBuilder()
+      .setAsInt(6)
+      .setTimeUnixNano(TIMESTAMP)
+      .addAttributesBuilder() // test sum with attributes
+      .setKey(METRIC_ATTRIBUTE_COLOR)
+      .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
+
+    // Create Second Metric
+    Metric.Builder gaugeMetricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
+        .addInstrumentationLibraryMetricsBuilder()
+        .addMetricsBuilder();
+
+    metricsDataBuilder.getResourceMetricsBuilder(1)
+        .getResourceBuilder()
+        .addAttributes(KeyValue.newBuilder()
+          .setKey(RESOURCE_ATTRIBUTE_ENV)
+          .setValue(AnyValue.newBuilder().setStringValue(RESOURCE_ATTRIBUTE_VALUE_DEVEL))
+          .build());
+
+    metricsDataBuilder.getResourceMetricsBuilder(1)
+      .getInstrumentationLibraryMetricsBuilder(0)
+      .getInstrumentationLibraryBuilder()
+      .setName(INSTRUMENTATION_LIBRARY_NAME)
+      .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+
+    gaugeMetricBuilder.setName("example_gauge")
+      .getGaugeBuilder()
+      .addDataPointsBuilder()
+      .setAsInt(8)
+      .setTimeUnixNano(TIMESTAMP)
+      .addAttributesBuilder() // test sum with attributes
+      .setKey(METRIC_ATTRIBUTE_FOO_KEY)
+      .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_FOO_VAL).build());
+
+    MetricsData metricsData = metricsDataBuilder.build();
+    ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,
+        -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
+    KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+         "descriptor.",
+        "custom.");
+
+    CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
+        new TimestampSpec("timestamp", "iso", null),
+        dimensionsSpec,
+        Collections.emptyList()
+    ), kafkaRecordEntity, null).read();
+
+
+    Assert.assertTrue(rows.hasNext());
+    InputRow row = rows.next();
+
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_sum");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+    assertDimensionEquals(row, "value", "6");
+
+    Assert.assertTrue(rows.hasNext());
+    row = rows.next();
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_gauge");
+    assertDimensionEquals(row, "custom.env", "devel");
+    assertDimensionEquals(row, "descriptor.foo_key", "foo_value");
+    assertDimensionEquals(row, "value", "8");
+
+  }
+
+  @Test
+  public void testDimensionSpecExclusions() throws IOException
+  {
+    metricsDataBuilder.getResourceMetricsBuilder(0)
+      .getResourceBuilder()
+      .addAttributesBuilder()
+      .setKey(RESOURCE_ATTRIBUTE_ENV)
+      .setValue(AnyValue.newBuilder().setStringValue(RESOURCE_ATTRIBUTE_VALUE_DEVEL).build());
+
+    metricBuilder.setName("example_gauge")
+        .getGaugeBuilder()
+        .addDataPointsBuilder()
+        .setAsInt(6)
+        .setTimeUnixNano(TIMESTAMP)
+        .addAllAttributes(ImmutableList.of(
+          KeyValue.newBuilder()
+            .setKey(METRIC_ATTRIBUTE_COLOR)
+            .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build()).build(),
+          KeyValue.newBuilder()
+            .setKey(METRIC_ATTRIBUTE_FOO_KEY)
+            .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_FOO_VAL).build()).build()));
+
+    DimensionsSpec dimensionsSpecWithExclusions = new DimensionsSpec(null,
+        ImmutableList.of(
+          "descriptor." + METRIC_ATTRIBUTE_COLOR,
+          "custom." + RESOURCE_ATTRIBUTE_COUNTRY
+        ), null);
+
+    MetricsData metricsData = metricsDataBuilder.build();
+    ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,
+        -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
+    KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        "descriptor.",
+        "custom.");
+
+    CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
+        new TimestampSpec("timestamp", "iso", null),
+        dimensionsSpecWithExclusions,
+        Collections.emptyList()
+    ), kafkaRecordEntity, null).read();
+
+
+    Assert.assertTrue(rows.hasNext());
+    InputRow row = rows.next();
+
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_gauge");
+    assertDimensionEquals(row, "value", "6");
+    assertDimensionEquals(row, "custom.env", "devel");
+    assertDimensionEquals(row, "descriptor.foo_key", "foo_value");
+    Assert.assertFalse(row.getDimensions().contains("custom.country"));
+    Assert.assertFalse(row.getDimensions().contains("descriptor.color"));
+  }
+
+  private void assertDimensionEquals(InputRow row, String dimension, Object expected)
+  {
+    List<String> values = row.getDimension(dimension);
+    Assert.assertEquals(1, values.size());
+    Assert.assertEquals(expected, values.get(0));
+  }
+
+}

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -137,6 +137,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
          -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
     KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
     OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        null,
         "descriptor.",
         "custom.");
 
@@ -175,6 +176,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
         -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
     KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
     OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        null,
         "descriptor.",
         "custom.");
     CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
@@ -237,6 +239,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
         -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
     KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
     OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        null,
          "descriptor.",
         "custom.");
 
@@ -299,6 +302,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
         -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
     KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
     OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        null,
         "descriptor.",
         "custom.");
 

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>protobuf-java</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+            <version>${opentelemetry.proto.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>provided</scope>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>io.opentelemetry.proto</groupId>
             <artifactId>opentelemetry-proto</artifactId>
-            <version>${opentelemetry.proto.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -43,11 +43,6 @@
             <artifactId>protobuf-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry.proto</groupId>
-            <artifactId>opentelemetry-proto</artifactId>
-            <version>${opentelemetry.proto.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>provided</scope>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -27,10 +27,6 @@
     <name>druid-opentelemetry-extensions</name>
     <description>druid-opentelemetry-extensions</description>
 
-    <properties>
-        <opentelemetry.proto.version>0.11.0-alpha</opentelemetry.proto.version>
-    </properties>
-
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
         <repoOrgId>apache.snapshots</repoOrgId>
         <repoOrgName>Apache Snapshot Repository</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/snapshots</repoOrgUrl>
+        <opentelemetry.proto.version>0.11.0-alpha</opentelemetry.proto.version>
 
         <!-- Allow the handful of flaky tests with transient failures to pass. -->
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
@@ -1266,6 +1267,12 @@
                 <groupId>io.timeandspace</groupId>
                 <artifactId>cron-scheduler</artifactId>
                 <version>0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.proto</groupId>
+                <artifactId>opentelemetry-proto</artifactId>
+                <version>${opentelemetry.proto.version}</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1272,7 +1272,6 @@
                 <groupId>io.opentelemetry.proto</groupId>
                 <artifactId>opentelemetry-proto</artifactId>
                 <version>${opentelemetry.proto.version}</version>
-                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.realtime.firehose;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.druid.collections.spatial.search.RadiusBound;
+import org.apache.druid.common.config.NullHandlingTest;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.DelimitedParseSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -66,7 +67,7 @@ import java.util.List;
 /**
  */
 @RunWith(Parameterized.class)
-public class IngestSegmentFirehoseTest
+public class IngestSegmentFirehoseTest extends NullHandlingTest
 {
   private static final DimensionsSpec DIMENSIONS_SPEC = new DimensionsSpec(
       ImmutableList.of(


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Based on the discussion with @xvrl , instead of using genetic ways of hybridding different formats based on different rules with headers regex matching, we decided to implement an easy and straight forward approach to hybrid the OpentelemetryMetricsProtobuf logic here. This PR created `OpentelemetryMetricsProtobufReader` within ` OpenCensusProtobufInputFormat#createReader` when header is `v1`.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist above are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

##### Key changed/added classes in this PR
 * `OpenCensusProtobufInputFormat`
 * `OpenTelemetryMetricsProtobufReaderTest`
