### PR TITLE
Adding JDK version to DockerFile and removing unwanted executions from main pom.xml file.

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+ARG JDK_VERSION=8
 FROM alpine as extractor
 
 ARG VERSION=

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -477,30 +477,6 @@
                       <dockerfile>docker/Dockerfile</dockerfile>
                     </configuration>
                   </execution>
-                  <execution>
-                    <id>tag-latest-jdk11</id>
-                    <goals>
-                      <goal>build</goal>
-                      <goal>tag</goal>
-                    </goals>
-                    <configuration>
-                      <repository>docker.io/apache/druid</repository>
-                      <tag>latest-jdk11</tag>
-                      <dockerfile>docker/Dockerfile.java11</dockerfile>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>tag-version-jdk11</id>
-                    <goals>
-                      <goal>build</goal>
-                      <goal>tag</goal>
-                    </goals>
-                    <configuration>
-                      <repository>docker.io/apache/druid</repository>
-                      <tag>${project.version}-jdk11</tag>
-                      <dockerfile>docker/Dockerfile.java11</dockerfile>
-                    </configuration>
-                  </execution>
                 </executions>
                 <configuration>
                   <buildArgs>


### PR DESCRIPTION
We don't have 2 different docker files anymore.

I was able to build a druid 0.22.1 image
```
REPOSITORY                                           TAG                                       IMAGE ID       CREATED          SIZE
apache/druid                                         0.22.1                                    9fbe41a7af67   13 minutes ago   787MB
```
Command used
```
mvn -DskipTests -DskipITs -Djacoco.skip=true -Danimal.sniffer.skip=true \
 -Dcheckstyle.skip=true -Denforcer.skip=true -Dforbiddenapis.skip=true \
 -Dmaven.javadoc.skip=true -Dpmd.skip=true -Dspotbugs.skip=true \
 package -P'!packaging,dist,bundle-contrib-exts,docker' \
 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
```