### PR TITLE
Passing JDK_VERSION as build args to docker build.

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -43,6 +43,7 @@
     <properties>
         <!-- the default value is a repeated flag from the command line, since blank value is not allowed -->
         <druid.distribution.pulldeps.opts>--clean</druid.distribution.pulldeps.opts>
+        <jdk.version>11</jdk.version>
     </properties>
 
     <build>
@@ -481,6 +482,7 @@
                 <configuration>
                   <buildArgs>
                     <VERSION>${project.version}</VERSION>
+                    <JDK_VERSION>${jdk.version}</JDK_VERSION>
                   </buildArgs>
                 </configuration>
               </plugin>


### PR DESCRIPTION
The default value in Dockerfile is 8. So, we are setting it to 11 via build args