### PR TITLE
Modify the OpenTelemetry ProtobufReader's Handling of Attribute Types

### DIFF
--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -97,7 +97,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
               .getAttributesList()
               .stream()
               .collect(HashMap::new,
-                  (m, kv)->m.put(resourceAttributePrefix + kv.getKey(), parseAnyValue(kv.getValue())),
+                  (m, kv) -> m.put(resourceAttributePrefix + kv.getKey(), parseAnyValue(kv.getValue())),
                   HashMap::putAll);
           return resourceMetrics.getInstrumentationLibraryMetricsList()
               .stream()
@@ -145,8 +145,8 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
   {
 
     int capacity = resourceAttributes.size()
-            + dataPoint.getAttributesCount()
-            + 2; // metric name + value columns
+        + dataPoint.getAttributesCount()
+        + 2; // metric name + value columns
     Map<String, Object> event = Maps.newHashMapWithExpectedSize(capacity);
     event.put(metricDimension, metricName);
 

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -36,8 +36,10 @@ import org.apache.druid.java.util.common.CloseableIterators;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -94,8 +96,9 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
           Map<String, Object> resourceAttributes = resourceMetrics.getResource()
               .getAttributesList()
               .stream()
-              .collect(Collectors.toMap(kv -> resourceAttributePrefix + kv.getKey(),
-                  kv -> parseAnyValue(kv.getValue())));
+              .collect(HashMap::new,
+                  (m, kv)->m.put(resourceAttributePrefix + kv.getKey(), parseAnyValue(kv.getValue())),
+                  HashMap::putAll);
           return resourceMetrics.getInstrumentationLibraryMetricsList()
               .stream()
               .flatMap(libraryMetrics -> libraryMetrics.getMetricsList()
@@ -160,6 +163,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
     return createRow(TimeUnit.NANOSECONDS.toMillis(dataPoint.getTimeUnixNano()), event);
   }
 
+  @Nullable
   private static Object parseAnyValue(AnyValue value)
   {
     switch (value.getValueCase()) {
@@ -167,19 +171,15 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
         return value.getIntValue();
       case BOOL_VALUE:
         return value.getBoolValue();
-      case ARRAY_VALUE:
-        return value.getArrayValue();
-      case BYTES_VALUE:
-        return value.getBytesValue();
       case DOUBLE_VALUE:
         return value.getDoubleValue();
-      case KVLIST_VALUE:
-        return value.getKvlistValue();
       case STRING_VALUE:
         return value.getStringValue();
+
+      // TODO: Support KVLIST_VALUE, ARRAY_VALUE and BYTES_VALUE
       default:
         // VALUE_NOT_SET:
-        return "";
+        return null;
     }
   }
 

--- a/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.druid.data.input.opencensus.protobuf.OpenCensusProtobufExtensionsModule
+org.apache.druid.data.input.opentelemetry.protobuf.OpenTelemetryMetricsProtobufInputFormat

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.data.input.opentelemetry.protobuf;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.common.v1.KeyValueList;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.MetricsData;
 import org.apache.druid.data.input.InputRow;
@@ -280,6 +281,67 @@ public class OpenTelemetryMetricsProtobufReaderTest
     assertDimensionEquals(row, "descriptor.foo_key", "foo_value");
     Assert.assertFalse(row.getDimensions().contains("custom.country"));
     Assert.assertFalse(row.getDimensions().contains("descriptor.color"));
+  }
+
+  @Test
+  public void testUnsupportedValueTypes()
+  {
+    KeyValueList kvList = KeyValueList.newBuilder()
+        .addValues(
+            KeyValue.newBuilder()
+                .setKey("foo")
+                .setValue(AnyValue.newBuilder().setStringValue("bar").build()))
+        .build();
+
+    metricsDataBuilder.getResourceMetricsBuilder(0)
+        .getResourceBuilder()
+        .addAttributesBuilder()
+        .setKey(RESOURCE_ATTRIBUTE_ENV)
+        .setValue(AnyValue.newBuilder().setKvlistValue(kvList).build());
+
+    metricBuilder
+        .setName("example_sum")
+        .getSumBuilder()
+        .addDataPointsBuilder()
+        .setAsInt(6)
+        .setTimeUnixNano(TIMESTAMP)
+        .addAllAttributes(ImmutableList.of(
+            KeyValue.newBuilder()
+                .setKey(METRIC_ATTRIBUTE_COLOR)
+                .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build()).build(),
+            KeyValue.newBuilder()
+                .setKey(METRIC_ATTRIBUTE_FOO_KEY)
+                .setValue(AnyValue.newBuilder().setKvlistValue(kvList).build()).build())
+        );
+
+    MetricsData metricsData = metricsDataBuilder.build();
+
+    CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
+        dimensionsSpec,
+        new ByteEntity(metricsData.toByteArray()),
+        "metric.name",
+        "raw.value",
+        "descriptor.",
+        "custom."
+    ).read();
+
+    List<InputRow> rowList = new ArrayList<>();
+    rows.forEachRemaining(rowList::add);
+    Assert.assertEquals(1, rowList.size());
+
+    InputRow row = rowList.get(0);
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_sum");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+
+    // Unsupported resource attribute type is omitted
+    Assert.assertEquals(0, row.getDimension("custom.env").size());
+
+    // Unsupported metric attribute type is omitted
+    Assert.assertEquals(0, row.getDimension("descriptor.foo_key").size());
+
+    assertDimensionEquals(row, "raw.value", "6");
   }
 
   private void assertDimensionEquals(InputRow row, String dimension, Object expected)

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -311,8 +311,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
                 .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build()).build(),
             KeyValue.newBuilder()
                 .setKey(METRIC_ATTRIBUTE_FOO_KEY)
-                .setValue(AnyValue.newBuilder().setKvlistValue(kvList).build()).build())
-        );
+                .setValue(AnyValue.newBuilder().setKvlistValue(kvList).build()).build()));
 
     MetricsData metricsData = metricsDataBuilder.build();
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes https://github.com/confluentinc/druid/pull/67

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
Only handle `INT_VALUE`, `BOOL_VALUE`, `DOUBLE_VALUE` and `STRING_VALUE` attribute types and return null otherwise

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...

##### Key changed/added classes in this PR
 * `OpenTelemetryMetricsProtobufReader`
