### PR TITLE
Fix Dependency Check in OpenTelemetry Extensions pom

### DIFF
--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -53,6 +53,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
### Description

Adds missing dependency that caused Analyze Dependency [semaphore failures](https://confluentinc.semaphoreci.com/jobs/2a72aa82-a977-4897-bc77-895fb0494b2f)

