### PR TITLE
Ingestion view task query optimization, UI change

### DIFF
--- a/web-console/src/views/ingestion-view/ingestion-view.tsx
+++ b/web-console/src/views/ingestion-view/ingestion-view.tsx
@@ -16,7 +16,8 @@
  * limitations under the License.
  */
 
-import { Alert, Button, ButtonGroup, Intent, Label, MenuItem } from '@blueprintjs/core';
+import { Alert, Button, ButtonGroup, Intent, Label, MenuItem, Switch } from '@blueprintjs/core';
+import { Tooltip2 } from '@blueprintjs/popover2';
 import { IconNames } from '@blueprintjs/icons';
 import React from 'react';
 import SplitterLayout from 'react-splitter-layout';
@@ -143,6 +144,8 @@ export interface IngestionViewState {
   supervisorTableActionDialogActions: BasicAction[];
   hiddenTaskColumns: LocalStorageBackedArray<string>;
   hiddenSupervisorColumns: LocalStorageBackedArray<string>;
+
+  preferOverlord: boolean;
 }
 
 function statusToColor(status: string): string {
@@ -242,6 +245,8 @@ ORDER BY "rank" DESC, "created_time" DESC`;
       hiddenSupervisorColumns: new LocalStorageBackedArray<string>(
         LocalStorageKeys.SUPERVISOR_TABLE_COLUMN_SELECTION,
       ),
+
+      preferOverlord: true,
     };
 
     this.supervisorQueryManager = new QueryManager({
@@ -278,25 +283,43 @@ ORDER BY "rank" DESC, "created_time" DESC`;
     });
 
     this.taskQueryManager = new QueryManager({
-      processQuery: async capabilities => {
-        if (capabilities.hasSql()) {
-          return await queryDruidSql({
-            query: IngestionView.TASK_SQL,
+        processQuery: async capabilities => {
+          const { preferOverlord } = this.state;
+          const hasOverlordAccess = capabilities.hasOverlordAccess();
+          const hasSql = capabilities.hasSql();
+
+          if (!hasOverlordAccess && !hasSql) {
+            throw new Error(`must have overlord or SQL access`);
+          }
+
+          if (preferOverlord) {
+            return hasOverlordAccess
+                        ? IngestionView.tasksViaOverlord()
+                        : IngestionView.tasksViaSql();
+          } else {
+            return hasSql
+                    ? IngestionView.tasksViaSql()
+                    : IngestionView.tasksViaOverlord();
+          }
+        },
+        onStateChange: tasksState => {
+          this.setState({
+            tasksState,
           });
-        } else if (capabilities.hasOverlordAccess()) {
-          const resp = await Api.instance.get(`/druid/indexer/v1/tasks`);
-          return IngestionView.parseTasks(resp.data);
-        } else {
-          throw new Error(`must have SQL or overlord access`);
-        }
-      },
-      onStateChange: tasksState => {
-        this.setState({
-          tasksState,
-        });
-      },
-    });
+        },
+     });
   }
+
+  static tasksViaSql = async () => {
+    return await queryDruidSql({
+      query: IngestionView.TASK_SQL,
+    });
+  };
+
+  static tasksViaOverlord = async () => {
+    const resp = await Api.instance.get(`/druid/indexer/v1/tasks`);
+    return IngestionView.parseTasks(resp.data);
+  };
 
   static parseTasks = (data: any[]): TaskQueryResultRow[] => {
     return data.map((d: any) => {
@@ -333,6 +356,13 @@ ORDER BY "rank" DESC, "created_time" DESC`;
     this.supervisorQueryManager.terminate();
     this.taskQueryManager.terminate();
   }
+
+  private handlePreferOverlordSwitchChange = () => {
+      this.setState(state => ({
+        ...state,
+        preferOverlord: !state.preferOverlord,
+      }));
+    };
 
   private readonly closeSpecDialogs = () => {
     this.setState({
@@ -1138,6 +1168,17 @@ ORDER BY "rank" DESC, "created_time" DESC`;
                 localStorageKey={LocalStorageKeys.TASKS_REFRESH_RATE}
                 onRefresh={auto => this.taskQueryManager.rerunLastQuery(auto)}
               />
+              {/* Toggle switch to prefer overload over SQL since SQL can affect metadata store performance with large number of tasks */}
+              <Tooltip2
+                content="Turning on the toggle will prefer overlord followed by sql for task listing. Turning off will reverse the order."
+                hoverOpenDelay={800}
+              >
+              <Switch
+                label="Prefer Overlord"
+                checked={this.state.preferOverlord}
+                onChange={this.handlePreferOverlordSwitchChange}
+              />
+              </Tooltip2>
               {this.renderBulkTasksActions()}
               <TableColumnSelector
                 columns={taskTableColumns}


### PR DESCRIPTION
Added a toggle button that steers queries to overlord or RDS. We will default it to overlord to reduce RDS stress.

Ticket has been filed upstream - https://github.com/apache/druid/issues/12318