### PR TITLE
Setting default refresh value for task view as none

### DIFF
--- a/web-console/src/components/refresh-button/refresh-button.tsx
+++ b/web-console/src/components/refresh-button/refresh-button.tsx
@@ -34,14 +34,15 @@ const DELAYS: DelayLabel[] = [
 export interface RefreshButtonProps {
   onRefresh: (auto: boolean) => void;
   localStorageKey?: LocalStorageKeys;
+  defaultDelay?: number;
 }
 
 export const RefreshButton = React.memo(function RefreshButton(props: RefreshButtonProps) {
-  const { onRefresh, localStorageKey } = props;
+  const { onRefresh, localStorageKey, defaultDelay = 30000 } = props;
 
   return (
     <TimedButton
-      defaultDelay={30000}
+      defaultDelay={defaultDelay}
       label="Auto refresh every"
       delays={DELAYS}
       icon={IconNames.REFRESH}

--- a/web-console/src/views/ingestion-view/ingestion-view.tsx
+++ b/web-console/src/views/ingestion-view/ingestion-view.tsx
@@ -1136,6 +1136,7 @@ ORDER BY "rank" DESC, "created_time" DESC`;
               </ButtonGroup>
               <RefreshButton
                 localStorageKey={LocalStorageKeys.TASKS_REFRESH_RATE}
+                defaultDelay={0}
                 onRefresh={auto => this.taskQueryManager.rerunLastQuery(auto)}
               />
               {this.renderBulkTasksActions()}


### PR DESCRIPTION
setting default refresh value for task view as none.

As part of this we added a default parameter that can be passed for refresh widget to avoid every refresh widget getting affected.