### PR TITLE
OBSDATA-440 Adding SegmentMetadataEvent and publishing them via KafkaSegmentMetadataEmitter

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEvent.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEvent.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.emitter.service;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.core.EventMap;
+import org.joda.time.DateTime;
+
+import java.util.Map;
+
+public class SegmentMetadataEvent implements Event
+{
+  public static final String FEED = "feed";
+  public static final String DATASOURCE = "dataSource";
+  public static final String CREATED_TIME = "createdTime";
+  public static final String START_TIME = "startTime";
+  public static final String END_TIME = "endTime";
+  public static final String VERSION = "version";
+  public static final String IS_COMPACTED = "isCompacted";
+
+  private final DateTime createdTime;
+  private final String dataSource;
+  private final DateTime startTime;
+  private final DateTime endTime;
+  private final String version;
+  private final boolean isCompacted;
+
+  public SegmentMetadataEvent(
+      String dataSource,
+      DateTime createdTime,
+      DateTime startTime,
+      DateTime endTime,
+      String version,
+      boolean isCompacted
+  )
+  {
+    this.dataSource = dataSource;
+    this.createdTime = createdTime;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.version = version;
+    this.isCompacted = isCompacted;
+  }
+
+  @Override
+  public String getFeed()
+  {
+    return "segment_metadata";
+  }
+
+  public DateTime getCreatedTime()
+  {
+    return createdTime;
+  }
+
+  public DateTime getStartTime()
+  {
+    return startTime;
+  }
+
+  public DateTime getEndTime()
+  {
+    return endTime;
+  }
+
+  public String getDataSource()
+  {
+    return dataSource;
+  }
+
+  public String getVersion()
+  {
+    return version;
+  }
+
+  public boolean isCompacted()
+  {
+    return isCompacted;
+  }
+
+  @Override
+  @JsonValue
+  public EventMap toMap()
+  {
+
+    return EventMap.builder()
+        .put(FEED, getFeed())
+        .put(DATASOURCE, dataSource)
+        .put(CREATED_TIME, createdTime)
+        .put(START_TIME, startTime)
+        .put(END_TIME, endTime)
+        .put(VERSION, version)
+        .put(IS_COMPACTED, isCompacted)
+        .build();
+  }
+}

--- a/core/src/test/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEventTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEventTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.emitter.service;
+
+import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SegmentMetadataEventTest
+{
+  @Test
+  public void testBasicEvent()
+  {
+    SegmentMetadataEvent event = new SegmentMetadataEvent(
+        "dummy_datasource",
+        DateTime.parse("2001-01-01T00:00:00.000Z"),
+        DateTime.parse("2001-01-02T00:00:00.000Z"),
+        DateTime.parse("2001-01-03T00:00:00.000Z"),
+        "dummy_version",
+        true
+    );
+
+    Assert.assertEquals(
+        ImmutableMap.<String, Object>builder()
+            .put(SegmentMetadataEvent.FEED, "segment_metadata")
+            .put(SegmentMetadataEvent.DATASOURCE, "dummy_datasource")
+            .put(SegmentMetadataEvent.CREATED_TIME, DateTime.parse("2001-01-01T00:00:00.000Z"))
+            .put(SegmentMetadataEvent.START_TIME, DateTime.parse("2001-01-02T00:00:00.000Z"))
+            .put(SegmentMetadataEvent.END_TIME, DateTime.parse("2001-01-03T00:00:00.000Z"))
+            .put(SegmentMetadataEvent.VERSION, "dummy_version")
+            .put(SegmentMetadataEvent.IS_COMPACTED, true)
+            .build(),
+        event.toMap()
+    );
+  }
+}

--- a/docs/development/extensions-contrib/kafka-emitter.md
+++ b/docs/development/extensions-contrib/kafka-emitter.md
@@ -36,20 +36,28 @@ to monitor the status of your Druid cluster with this extension.
 
 All the configuration parameters for the Kafka emitter are under `druid.emitter.kafka`.
 
-|property|description|required?|default|
-|--------|-----------|---------|-------|
-|`druid.emitter.kafka.bootstrap.servers`|Comma-separated Kafka broker. (`[hostname:port],[hostname:port]...`)|yes|none|
-|`druid.emitter.kafka.metric.topic`|Kafka topic name for emitter's target to emit service metric.|yes|none|
-|`druid.emitter.kafka.alert.topic`|Kafka topic name for emitter's target to emit alert.|yes|none|
-|`druid.emitter.kafka.request.topic`|Kafka topic name for emitter's target to emit request logs. If left empty then request logs will not be sent to the Kafka topic.|no|none|
-|`druid.emitter.kafka.producer.config`|JSON formatted configuration which user want to set additional properties to Kafka producer.|no|none|
-|`druid.emitter.kafka.clusterName`|Optional value to specify name of your druid cluster. It can help make groups in your monitoring environment. |no|none|
+| property                                           | description                                                                                                                                                                             | required? | default               |
+|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|-----------------------|
+| `druid.emitter.kafka.bootstrap.servers`            | Comma-separated Kafka broker. (`[hostname:port],[hostname:port]...`)                                                                                                                    | yes       | none                  |
+| `druid.emitter.kafka.event.types`                  | Comma-separated event types. <br/>Choices: alerts, metrics, requests, segmentMetadata                                                                                                   | no        | ["metrics", "alerts"] |
+| `druid.emitter.kafka.metric.topic`                 | Kafka topic name for emitter's target to emit service metric. If `event.types` contains `metrics`, this field cannot be left empty                                                      | no        | none                  |
+| `druid.emitter.kafka.alert.topic`                  | Kafka topic name for emitter's target to emit alert. If `event.types` contains `alerts`, this field cannot be left empty                                                                | no        | none                  |
+| `druid.emitter.kafka.request.topic`                | Kafka topic name for emitter's target to emit request logs. If `event.types` contains `requests`, this field cannot be left empty                                                       | no        | none                  |
+| `druid.emitter.kafka.segmentMetadata.topic`        | Kafka topic name for emitter's target to emit segments related metadata. If `event.types` contains `segmentMetadata`, this field cannot be left empty                                   | no        | none                  |
+| `druid.emitter.kafka.segmentMetadata.topic.format` | Format in which segment related metadata will be emitted. <br/>Choices: json, protobuf.<br/> If set to `protobuf`, then segment metadata is emitted in `DruidSegmentEvent.proto` format | no        | json                  |
+| `druid.emitter.kafka.producer.config`              | JSON formatted configuration which user want to set additional properties to Kafka producer.                                                                                            | no        | none                  |
+| `druid.emitter.kafka.clusterName`                  | Optional value to specify name of your druid cluster. It can help make groups in your monitoring environment.                                                                           | no        | none                  |
 
 ### Example
 
 ```
 druid.emitter.kafka.bootstrap.servers=hostname1:9092,hostname2:9092
-druid.emitter.kafka.metric.topic=druid-metric
+druid.emitter.kafka.event.types=["alerts", "requests", "segmentMetadata"]
 druid.emitter.kafka.alert.topic=druid-alert
+druid.emitter.kafka.request.topic=druid-request-logs
+druid.emitter.kafka.segmentMetadata.topic=druid-segment-metadata
+druid.emitter.kafka.segmentMetadata.topic.format=protobuf 
 druid.emitter.kafka.producer.config={"max.block.ms":10000}
 ```
+Whenever `druid.emitter.kafka.segmentMetadata.topic.format` field is updated, it is recommended to also update  `druid.emitter.kafka.segmentMetadata.topic` to avoid the same topic from getting polluted with different formats of segment metadata.
+

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -112,5 +112,43 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+    </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>detect</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -19,17 +19,20 @@
 
 package org.apache.druid.emitter.kafka;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import org.apache.druid.emitter.kafka.KafkaEmitterConfig.EventType;
 import org.apache.druid.emitter.kafka.MemoryBoundLinkedBlockingQueue.ObjectContainer;
-import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.emitter.proto.DruidSegmentEvent;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.core.Emitter;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.core.EventMap;
 import org.apache.druid.java.util.emitter.service.AlertEvent;
+import org.apache.druid.java.util.emitter.service.SegmentMetadataEvent;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.server.log.RequestLogEvent;
 import org.apache.kafka.clients.producer.Callback;
@@ -37,9 +40,11 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -55,14 +60,16 @@ public class KafkaEmitter implements Emitter
   private final AtomicLong metricLost;
   private final AtomicLong alertLost;
   private final AtomicLong requestLost;
+  private final AtomicLong segmentMetadataLost;
   private final AtomicLong invalidLost;
 
   private final KafkaEmitterConfig config;
-  private final Producer<String, String> producer;
+  private final Producer<String, byte[]> producer;
   private final ObjectMapper jsonMapper;
-  private final MemoryBoundLinkedBlockingQueue<String> metricQueue;
-  private final MemoryBoundLinkedBlockingQueue<String> alertQueue;
-  private final MemoryBoundLinkedBlockingQueue<String> requestQueue;
+  private final MemoryBoundLinkedBlockingQueue<byte[]> metricQueue;
+  private final MemoryBoundLinkedBlockingQueue<byte[]> alertQueue;
+  private final MemoryBoundLinkedBlockingQueue<byte[]> requestQueue;
+  private final MemoryBoundLinkedBlockingQueue<byte[]> segmentMetadataQueue;
   private final ScheduledExecutorService scheduler;
 
   protected int sendInterval = DEFAULT_SEND_INTERVAL_SECONDS;
@@ -78,10 +85,12 @@ public class KafkaEmitter implements Emitter
     this.metricQueue = new MemoryBoundLinkedBlockingQueue<>(queueMemoryBound);
     this.alertQueue = new MemoryBoundLinkedBlockingQueue<>(queueMemoryBound);
     this.requestQueue = new MemoryBoundLinkedBlockingQueue<>(queueMemoryBound);
+    this.segmentMetadataQueue = new MemoryBoundLinkedBlockingQueue<>(queueMemoryBound);
     this.scheduler = Executors.newScheduledThreadPool(4);
     this.metricLost = new AtomicLong(0L);
     this.alertLost = new AtomicLong(0L);
     this.requestLost = new AtomicLong(0L);
+    this.segmentMetadataLost = new AtomicLong(0L);
     this.invalidLost = new AtomicLong(0L);
   }
 
@@ -96,7 +105,7 @@ public class KafkaEmitter implements Emitter
   }
 
   @VisibleForTesting
-  protected Producer<String, String> setKafkaProducer()
+  protected Producer<String, byte[]> setKafkaProducer()
   {
     ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
     try {
@@ -105,7 +114,7 @@ public class KafkaEmitter implements Emitter
       Properties props = new Properties();
       props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
       props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-      props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
       props.put(ProducerConfig.RETRIES_CONFIG, DEFAULT_RETRIES);
       props.putAll(config.getKafkaProducerConfig());
 
@@ -119,18 +128,26 @@ public class KafkaEmitter implements Emitter
   @Override
   public void start()
   {
-    scheduler.schedule(this::sendMetricToKafka, sendInterval, TimeUnit.SECONDS);
-    scheduler.schedule(this::sendAlertToKafka, sendInterval, TimeUnit.SECONDS);
-    if (config.getRequestTopic() != null) {
+    Set<EventType> eventTypes = config.getEventTypes();
+    if (eventTypes.contains(EventType.METRICS)) {
+      scheduler.schedule(this::sendMetricToKafka, sendInterval, TimeUnit.SECONDS);
+    }
+    if (eventTypes.contains(EventType.ALERTS)) {
+      scheduler.schedule(this::sendAlertToKafka, sendInterval, TimeUnit.SECONDS);
+    }
+    if (eventTypes.contains(EventType.REQUESTS)) {
       scheduler.schedule(this::sendRequestToKafka, sendInterval, TimeUnit.SECONDS);
     }
+    if (eventTypes.contains(EventType.SEGMENTMETADATA)) {
+      scheduler.schedule(this::sendSegmentMetadataToKafka, sendInterval, TimeUnit.SECONDS);
+    }
     scheduler.scheduleWithFixedDelay(() -> {
-      log.info(
-          "Message lost counter: metricLost=[%d], alertLost=[%d], requestLost=[%d], invalidLost=[%d]",
+      log.info("Message lost counter: metricLost=[%d], alertLost=[%d], requestLost=[%d], invalidLost=[%d] segmentMetadataLost=[%d]",
           metricLost.get(),
           alertLost.get(),
           requestLost.get(),
-          invalidLost.get()
+          invalidLost.get(),
+          segmentMetadataLost.get()
       );
     }, DEFAULT_SEND_LOST_INTERVAL_MINUTES, DEFAULT_SEND_LOST_INTERVAL_MINUTES, TimeUnit.MINUTES);
     log.info("Starting Kafka Emitter.");
@@ -151,9 +168,14 @@ public class KafkaEmitter implements Emitter
     sendToKafka(config.getRequestTopic(), requestQueue, setProducerCallback(requestLost));
   }
 
-  private void sendToKafka(final String topic, MemoryBoundLinkedBlockingQueue<String> recordQueue, Callback callback)
+  private void sendSegmentMetadataToKafka()
   {
-    ObjectContainer<String> objectToSend;
+    sendToKafka(config.getSegmentMetadataTopic(), segmentMetadataQueue, setProducerCallback(segmentMetadataLost));
+  }
+
+  private void sendToKafka(final String topic, MemoryBoundLinkedBlockingQueue<byte[]> recordQueue, Callback callback)
+  {
+    ObjectContainer<byte[]> objectToSend;
     try {
       while (true) {
         objectToSend = recordQueue.take();
@@ -173,35 +195,84 @@ public class KafkaEmitter implements Emitter
         EventMap map = event.toMap();
         if (config.getClusterName() != null) {
           map = map.asBuilder()
-                   .put("clusterName", config.getClusterName())
-                   .build();
+              .put("clusterName", config.getClusterName())
+              .build();
         }
 
-        String resultJson = jsonMapper.writeValueAsString(map);
-
-        ObjectContainer<String> objectContainer = new ObjectContainer<>(
-            resultJson,
-            StringUtils.toUtf8(resultJson).length
+        byte[] resultBytes = jsonMapper.writeValueAsBytes(map);
+        ObjectContainer<byte[]> objectContainer = new ObjectContainer<>(
+            resultBytes,
+            resultBytes.length
         );
+        Set<EventType> eventTypes = config.getEventTypes();
         if (event instanceof ServiceMetricEvent) {
-          if (!metricQueue.offer(objectContainer)) {
+          if (!eventTypes.contains(EventType.METRICS) || !metricQueue.offer(objectContainer)) {
             metricLost.incrementAndGet();
           }
         } else if (event instanceof AlertEvent) {
-          if (!alertQueue.offer(objectContainer)) {
+          if (!eventTypes.contains(EventType.ALERTS) || !alertQueue.offer(objectContainer)) {
             alertLost.incrementAndGet();
           }
         } else if (event instanceof RequestLogEvent) {
-          if (config.getRequestTopic() == null || !requestQueue.offer(objectContainer)) {
+          if (!eventTypes.contains(EventType.REQUESTS) || !requestQueue.offer(objectContainer)) {
             requestLost.incrementAndGet();
+          }
+        } else if (event instanceof SegmentMetadataEvent) {
+          if (!eventTypes.contains(EventType.SEGMENTMETADATA) ) {
+            segmentMetadataLost.incrementAndGet();
+          } else {
+            switch (config.getSegmentMetadataTopicFormat()) {
+              case PROTOBUF:
+                resultBytes = convertMetadataEventToProto((SegmentMetadataEvent) event, segmentMetadataLost);
+                objectContainer = new ObjectContainer<>(
+                    resultBytes,
+                    resultBytes.length
+                );
+                break;
+              case JSON:
+                // Do Nothing. We already have the JSON object stored in objectContainer
+                break;
+              default:
+                throw new UnsupportedOperationException("segmentMetadata.topic.format has an invalid value " + config.getSegmentMetadataTopicFormat().toString());
+            }
+            if (!segmentMetadataQueue.offer(objectContainer)) {
+              segmentMetadataLost.incrementAndGet();
+            }
           }
         } else {
           invalidLost.incrementAndGet();
         }
       }
-      catch (JsonProcessingException e) {
+      catch (Exception e) {
         invalidLost.incrementAndGet();
+        log.warn(e, "Exception while serializing event");
       }
+    }
+  }
+
+  private byte[] convertMetadataEventToProto(SegmentMetadataEvent event, AtomicLong segmentMetadataLost)
+  {
+    try {
+      Timestamp createdTimeTs = Timestamps.fromMillis(event.getCreatedTime().getMillis());
+      Timestamp startTimeTs = Timestamps.fromMillis(event.getStartTime().getMillis());
+      Timestamp endTimeTs = Timestamps.fromMillis(event.getEndTime().getMillis());
+
+      DruidSegmentEvent.Builder druidSegmentEventBuilder = DruidSegmentEvent.newBuilder()
+          .setDataSource(event.getDataSource())
+          .setCreatedTime(createdTimeTs)
+          .setStartTime(startTimeTs)
+          .setEndTime(endTimeTs)
+          .setVersion(event.getVersion())
+          .setIsCompacted(event.isCompacted());
+      if (config.getClusterName() != null) {
+        druidSegmentEventBuilder.setClusterName(config.getClusterName());
+      }
+      DruidSegmentEvent druidSegmentEvent = druidSegmentEventBuilder.build();
+      return druidSegmentEvent.toByteArray();
+    }
+    catch (Exception e) {
+      log.warn(e, "Exception while serializing SegmentMetadataEvent");
+      throw e;
     }
   }
 
@@ -237,5 +308,10 @@ public class KafkaEmitter implements Emitter
   public long getInvalidLostCount()
   {
     return invalidLost.get();
+  }
+
+  public long getSegmentMetadataLostCount()
+  {
+    return segmentMetadataLost.get();
   }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -21,51 +21,138 @@ package org.apache.druid.emitter.kafka;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class KafkaEmitterConfig
 {
+  public enum EventType
+  {
+    METRICS,
+    ALERTS,
+    REQUESTS,
+    SEGMENTMETADATA{
+      @Override
+      public String toString()
+      {
+        return "segmentMetadata";
+      }
+    };
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return StringUtils.toLowerCase(this.name());
+    }
+
+    @JsonCreator
+    public static EventType fromString(String name)
+    {
+      return valueOf(StringUtils.toUpperCase(name));
+    }
+  }
+
+  public static final Set<EventType> DEFAULT_EVENT_TYPES = ImmutableSet.of(EventType.ALERTS, EventType.METRICS);
+
+  public enum SegmentMetadataTopicFormat
+  {
+    JSON,
+    PROTOBUF;
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return StringUtils.toLowerCase(this.name());
+    }
+
+    @JsonCreator
+    public static SegmentMetadataTopicFormat fromString(String name)
+    {
+      return valueOf(StringUtils.toUpperCase(name));
+    }
+  }
 
   @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
   private final String bootstrapServers;
-  @JsonProperty("metric.topic")
+  @Nullable @JsonProperty("event.types")
+  private final Set<EventType> eventTypes;
+  @Nullable @JsonProperty("metric.topic")
   private final String metricTopic;
-  @JsonProperty("alert.topic")
+  @Nullable @JsonProperty("alert.topic")
   private final String alertTopic;
   @Nullable @JsonProperty("request.topic")
   private final String requestTopic;
+  @Nullable @JsonProperty("segmentMetadata.topic")
+  private final String segmentMetadataTopic;
+  @Nullable @JsonProperty("segmentMetadata.topic.format")
+  private final SegmentMetadataTopicFormat segmentMetadataTopicFormat;
   @JsonProperty
   private final String clusterName;
   @JsonProperty("producer.config")
-  private Map<String, String> kafkaProducerConfig;
+  private final Map<String, String> kafkaProducerConfig;
 
   @JsonCreator
   public KafkaEmitterConfig(
       @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
-      @JsonProperty("metric.topic") String metricTopic,
-      @JsonProperty("alert.topic") String alertTopic,
+      @Nullable @JsonProperty("event.types") Set<EventType> eventTypes,
+      @Nullable @JsonProperty("metric.topic") String metricTopic,
+      @Nullable @JsonProperty("alert.topic") String alertTopic,
       @Nullable @JsonProperty("request.topic") String requestTopic,
+      @Nullable @JsonProperty("segmentMetadata.topic") String segmentMetadataTopic,
+      @Nullable @JsonProperty("segmentMetadata.topic.format") SegmentMetadataTopicFormat segmentMetadataTopicFormat,
       @JsonProperty("clusterName") String clusterName,
       @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig
   )
   {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
-    this.metricTopic = Preconditions.checkNotNull(metricTopic, "metric.topic can not be null");
-    this.alertTopic = Preconditions.checkNotNull(alertTopic, "alert.topic can not be null");
-    this.requestTopic = requestTopic;
+    this.eventTypes = validateEventTypes(eventTypes, requestTopic);
+    this.segmentMetadataTopicFormat = segmentMetadataTopicFormat == null ? SegmentMetadataTopicFormat.JSON : segmentMetadataTopicFormat;
+
+    this.metricTopic = this.eventTypes.contains(EventType.METRICS) ? Preconditions.checkNotNull(metricTopic, "metric.topic can not be null") : null;
+    this.alertTopic = this.eventTypes.contains(EventType.ALERTS) ? Preconditions.checkNotNull(alertTopic, "alert.topic can not be null") : null;
+    this.requestTopic = this.eventTypes.contains(EventType.REQUESTS) ? Preconditions.checkNotNull(requestTopic, "request.topic can not be null") : null;
+    this.segmentMetadataTopic = this.eventTypes.contains(EventType.SEGMENTMETADATA) ? Preconditions.checkNotNull(segmentMetadataTopic, "segmentMetadata.topic can not be null") : null;
     this.clusterName = clusterName;
     this.kafkaProducerConfig = kafkaProducerConfig == null ? ImmutableMap.of() : kafkaProducerConfig;
+  }
+
+  private Set<EventType> validateEventTypes(Set<EventType> eventTypes, String requestTopic)
+  {
+    // Unless explicitly overridden, kafka emitter will always emit metrics and alerts
+    if (eventTypes == null) {
+      Set<EventType> defaultEventTypes = new HashSet<>(DEFAULT_EVENT_TYPES);
+      // To maintain backwards compatibility, if eventTypes is not set, then requests are sent out or not
+      // based on the `request.topic` config
+      if (requestTopic != null) {
+        defaultEventTypes.add(EventType.REQUESTS);
+      }
+      return defaultEventTypes;
+    }
+    return eventTypes;
   }
 
   @JsonProperty
   public String getBootstrapServers()
   {
     return bootstrapServers;
+  }
+
+  @JsonProperty
+  public Set<EventType> getEventTypes()
+  {
+    return eventTypes;
   }
 
   @JsonProperty
@@ -92,6 +179,18 @@ public class KafkaEmitterConfig
     return requestTopic;
   }
 
+  @Nullable
+  public String getSegmentMetadataTopic()
+  {
+    return segmentMetadataTopic;
+  }
+
+  @JsonProperty
+  public SegmentMetadataTopicFormat getSegmentMetadataTopicFormat()
+  {
+    return segmentMetadataTopicFormat;
+  }
+
   @JsonProperty
   public Map<String, String> getKafkaProducerConfig()
   {
@@ -113,14 +212,28 @@ public class KafkaEmitterConfig
     if (!getBootstrapServers().equals(that.getBootstrapServers())) {
       return false;
     }
-    if (!getMetricTopic().equals(that.getMetricTopic())) {
+
+    if (getEventTypes() != null ? !getEventTypes().equals(that.getEventTypes()) : that.getEventTypes() != null) {
       return false;
     }
-    if (!getAlertTopic().equals(that.getAlertTopic())) {
+
+    if (getMetricTopic() != null ? !getMetricTopic().equals(that.getMetricTopic()) : that.getMetricTopic() != null) {
+      return false;
+    }
+
+    if (getAlertTopic() != null ? !getAlertTopic().equals(that.getAlertTopic()) : that.getAlertTopic() != null) {
       return false;
     }
 
     if (getRequestTopic() != null ? !getRequestTopic().equals(that.getRequestTopic()) : that.getRequestTopic() != null) {
+      return false;
+    }
+
+    if (getSegmentMetadataTopic() != null ? !getSegmentMetadataTopic().equals(that.getSegmentMetadataTopic()) : that.getSegmentMetadataTopic() != null) {
+      return false;
+    }
+
+    if (getSegmentMetadataTopicFormat() != null ? !getSegmentMetadataTopicFormat().equals(that.getSegmentMetadataTopicFormat()) : that.getSegmentMetadataTopicFormat() != null) {
       return false;
     }
 
@@ -134,9 +247,12 @@ public class KafkaEmitterConfig
   public int hashCode()
   {
     int result = getBootstrapServers().hashCode();
-    result = 31 * result + getMetricTopic().hashCode();
-    result = 31 * result + getAlertTopic().hashCode();
+    result = 31 * result + (getEventTypes() != null ? getEventTypes().hashCode() : 0);
+    result = 31 * result + (getMetricTopic() != null ? getMetricTopic().hashCode() : 0);
+    result = 31 * result + (getAlertTopic() != null ? getAlertTopic().hashCode() : 0);
     result = 31 * result + (getRequestTopic() != null ? getRequestTopic().hashCode() : 0);
+    result = 31 * result + (getSegmentMetadataTopic() != null ? getSegmentMetadataTopic().hashCode() : 0);
+    result = 31 * result + (getSegmentMetadataTopicFormat() != null ? getSegmentMetadataTopicFormat().hashCode() : 0);
     result = 31 * result + (getClusterName() != null ? getClusterName().hashCode() : 0);
     result = 31 * result + getKafkaProducerConfig().hashCode();
     return result;
@@ -147,9 +263,12 @@ public class KafkaEmitterConfig
   {
     return "KafkaEmitterConfig{" +
            "bootstrap.servers='" + bootstrapServers + '\'' +
+           ", event.types='" + eventTypes.toString() + '\'' +
            ", metric.topic='" + metricTopic + '\'' +
            ", alert.topic='" + alertTopic + '\'' +
            ", request.topic='" + requestTopic + '\'' +
+           ", segmentMetadata.topic='" + segmentMetadataTopic + '\'' +
+           ", segmentMetadata.topic.format='" + segmentMetadataTopicFormat + '\'' +
            ", clusterName='" + clusterName + '\'' +
            ", Producer.config=" + kafkaProducerConfig +
            '}';

--- a/extensions-contrib/kafka-emitter/src/main/proto/DruidSegmentEvent.proto
+++ b/extensions-contrib/kafka-emitter/src/main/proto/DruidSegmentEvent.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+import "google/protobuf/timestamp.proto";
+
+option java_multiple_files = true;
+option java_package = "org.apache.druid.emitter.proto";
+option java_outer_classname = "DruidSegmentEventMessage";
+
+/* Druid segment Event used by Druid to publish first level segment information.
+ * The message will be consumed by segment processing app. */
+message DruidSegmentEvent {
+    string dataSource = 1;
+
+    // When this event was created
+    google.protobuf.Timestamp createdTime = 2;
+
+    // Start time of the segment
+    google.protobuf.Timestamp startTime = 3;
+
+    // End time of the segment
+    google.protobuf.Timestamp endTime = 4;
+
+    // Segment version
+    string version = 5;
+
+    // Cluster name
+    string clusterName = 6;
+
+    // Is the segment compacted or not
+    bool isCompacted = 7;
+}

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -19,14 +19,15 @@
 
 package org.apache.druid.emitter.kafka;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
 import java.io.IOException;
 
 public class KafkaEmitterConfigTest
@@ -42,8 +43,8 @@ public class KafkaEmitterConfigTest
   @Test
   public void testSerDeserKafkaEmitterConfig() throws IOException
   {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
-        "alertTest", "requestTest",
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", null, "metricTest",
+        "alertTest", "requestTest", "metadataTest", null,
         "clusterNameTest", ImmutableMap.<String, String>builder()
         .put("testKey", "testValue").build()
     );
@@ -56,8 +57,8 @@ public class KafkaEmitterConfigTest
   @Test
   public void testSerDeserKafkaEmitterConfigNullRequestTopic() throws IOException
   {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
-        "alertTest", null,
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", null, "metricTest",
+        "alertTest", null, "metadataTest", null,
         "clusterNameTest", ImmutableMap.<String, String>builder()
         .put("testKey", "testValue").build()
     );
@@ -70,8 +71,8 @@ public class KafkaEmitterConfigTest
   @Test
   public void testSerDeNotRequiredKafkaProducerConfig()
   {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", "metricTest",
-        "alertTest", null,
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", null, "metricTest",
+        "alertTest", null, "metadataTest", null,
         "clusterNameTest", null
     );
     try {
@@ -81,6 +82,14 @@ public class KafkaEmitterConfigTest
     catch (NullPointerException e) {
       Assert.fail();
     }
+  }
+
+  @Test
+  public void testDeserializeEventTypesWithDifferentCase() throws JsonProcessingException
+  {
+    Assert.assertEquals(KafkaEmitterConfig.EventType.SEGMENTMETADATA, mapper.readValue("\"segmentMetadata\"", KafkaEmitterConfig.EventType.class));
+    Assert.assertEquals(KafkaEmitterConfig.EventType.ALERTS, mapper.readValue("\"alerts\"", KafkaEmitterConfig.EventType.class));
+    Assert.assertThrows(ValueInstantiationException.class, () -> mapper.readValue("\"segment_metadata\"", KafkaEmitterConfig.EventType.class));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -721,6 +721,11 @@
                 <version>${protobuf.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java-util</artifactId>
+                <version>${protobuf.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.tesla.aether</groupId>
                 <artifactId>tesla-aether</artifactId>
                 <version>0.0.5</version>


### PR DESCRIPTION
Adding the new `SegmentMetadataEvent` and publishing these segment-related metadata events into Kafka by enhancing the `KafkaEmitter`

### Description
In this PR, we are enhancing `KafkaEmitter`, to emit metadata about published segments (`SegmentMetadataEvent`) into a Kafka topic. This segment metadata information that gets published into Kafka, can be used by any other downstream services to query Druid intelligently based on the segments published.

#### Old behavior of Kafka Emitter
Kafka Emitter always emits `metrics` and `alerts` and would emit `requests` if the config `request.topic` is configured.
Configs `metric.topic` and `alert.topic` are always mandatory and cannot be `null`.

#### Current behavior of Kafka Emitter [with backwards compatibility]
We introduced a new config named `event.types` which dictates the types of events we want the `KafkaEmitter` to emit. This config takes in a list of strings and can have one or more from `[alerts, metrics, requests and segmentMetadata]`. And based on this config, `alert.topic`, `request.topic`, `metric.topic` and `segmentMetadata.topic` should be configured and not left empty.
If no `event.types` is set, then by default, the kafka emitter would emit `metrics` and `alerts`. And in that case, to maintain backwards compatibility, decision to send out requests are based on if `request.topic` is empty or set.

#### Metadata format
The emitter by default would emit the metadata in json string format. If `segment.metadata.format` is set to `protobuf`, then the emitter emits it in protobuf format.

### Testing Done
- Added unit tests
- Tested by running Druid and ingesting data.
- Enabled compaction and verified the fields are appropriately set in the `SegmentMetadataEvent` class
- Verified `SegmentMetadataEvent` is getting published in Kafka

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.