### PR TITLE
OBSDATA-483: Adapt OpenCensus and OpenTelemetry extensions to the introduction of SettableByteEntity

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,10 +4,6 @@ agent:
   machine:
     type: s1-prod-ubuntu20-04-amd64-1
 
-# Increase time limit to allow tests to run to completion
-execution_time_limit:
-  hours: 2
-
 blocks:
   - name: "Install"
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,6 +4,10 @@ agent:
   machine:
     type: s1-prod-ubuntu20-04-amd64-1
 
+# Increase time limit to allow tests to run to completion
+execution_time_limit:
+  hours: 2
+
 blocks:
   - name: "Install"
     task:

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -56,6 +56,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-indexing-service</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry.proto</groupId>
       <artifactId>opentelemetry-proto</artifactId>
     </dependency>

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
@@ -35,8 +35,8 @@ import java.lang.invoke.MethodHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import static org.apache.druid.data.input.opencensus.protobuf.HybridProtobufReader.ProtobufReader.OPEN_CENSUS;
-import static org.apache.druid.data.input.opencensus.protobuf.HybridProtobufReader.ProtobufReader.OPEN_TELEMETRY;
+import static org.apache.druid.data.input.opencensus.protobuf.HybridProtobufReader.ProtobufReader.OPENCENSUS;
+import static org.apache.druid.data.input.opencensus.protobuf.HybridProtobufReader.ProtobufReader.OPENTELEMETRY;
 
 public class HybridProtobufReader implements InputEntityReader
 {
@@ -53,8 +53,8 @@ public class HybridProtobufReader implements InputEntityReader
   private volatile MethodHandle getHeaderMethod = null;
 
   enum ProtobufReader {
-    OPEN_CENSUS,
-    OPEN_TELEMETRY
+    OPENCENSUS,
+    OPENTELEMETRY
   }
 
   public HybridProtobufReader(
@@ -83,7 +83,7 @@ public class HybridProtobufReader implements InputEntityReader
   public InputEntityReader newReader(ProtobufReader which)
   {
     switch(which) {
-      case OPEN_TELEMETRY:
+      case OPENTELEMETRY:
         return new OpenTelemetryMetricsProtobufReader(
             dimensionsSpec,
             source,
@@ -92,7 +92,7 @@ public class HybridProtobufReader implements InputEntityReader
             metricLabelPrefix,
             resourceLabelPrefix
         );
-      case OPEN_CENSUS:
+      case OPENCENSUS:
       default:
         return new OpenCensusProtobufReader(
             dimensionsSpec,
@@ -121,14 +121,14 @@ public class HybridProtobufReader implements InputEntityReader
         int version =
             ByteBuffer.wrap(versionHeader).order(ByteOrder.LITTLE_ENDIAN).getInt();
         if (version == OPENTELEMETRY_FORMAT_VERSION) {
-          return OPEN_TELEMETRY;
+          return OPENTELEMETRY;
         }
       }
     }
     catch (Throwable t) {
       // assume input is opencensus if something went wrong
     }
-    return OPEN_CENSUS;
+    return OPENCENSUS;
   }
 
   @Override

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opencensus.protobuf;
+
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowListPlusRawValues;
+import org.apache.druid.data.input.KafkaUtils;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.opentelemetry.protobuf.OpenTelemetryMetricsProtobufReader;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.apache.druid.data.input.opencensus.protobuf.HybridProtobufReader.ProtobufReader.OPEN_CENSUS;
+import static org.apache.druid.data.input.opencensus.protobuf.HybridProtobufReader.ProtobufReader.OPEN_TELEMETRY;
+
+public class HybridProtobufReader implements InputEntityReader
+{
+  private static final String VERSION_HEADER_KEY = "v";
+  private static final int OPENTELEMETRY_FORMAT_VERSION = 1;
+
+  private final DimensionsSpec dimensionsSpec;
+  private final SettableByteEntity<? extends ByteEntity> source;
+  private final String metricDimension;
+  private final String valueDimension;
+  private final String metricLabelPrefix;
+  private final String resourceLabelPrefix;
+
+  private volatile MethodHandle getHeaderMethod = null;
+
+  enum ProtobufReader {
+    OPEN_CENSUS,
+    OPEN_TELEMETRY
+  }
+
+  public HybridProtobufReader(
+      DimensionsSpec dimensionsSpec,
+      SettableByteEntity<? extends ByteEntity> source,
+      String metricDimension,
+      String valueDimension,
+      String metricLabelPrefix,
+      String resourceLabelPrefix
+  )
+  {
+    this.dimensionsSpec = dimensionsSpec;
+    this.source = source;
+    this.metricDimension = metricDimension;
+    this.valueDimension = valueDimension;
+    this.metricLabelPrefix = metricLabelPrefix;
+    this.resourceLabelPrefix = resourceLabelPrefix;
+  }
+
+  @Override
+  public CloseableIterator<InputRow> read() throws IOException
+  {
+    return newReader(whichReader()).read();
+  }
+
+  public InputEntityReader newReader(ProtobufReader which)
+  {
+    switch(which) {
+      case OPEN_TELEMETRY:
+        return new OpenTelemetryMetricsProtobufReader(
+            dimensionsSpec,
+            source,
+            metricDimension,
+            valueDimension,
+            metricLabelPrefix,
+            resourceLabelPrefix
+        );
+      case OPEN_CENSUS:
+      default:
+        return new OpenCensusProtobufReader(
+            dimensionsSpec,
+            source,
+            metricDimension,
+            metricLabelPrefix,
+            resourceLabelPrefix
+        );
+    }
+  }
+
+  public ProtobufReader whichReader()
+  {
+    // assume InputEntity is always defined in a single classloader (the kafka-indexing-service classloader)
+    // so we only have to look it up once. To be completely correct we should cache the method based on classloader
+    if (getHeaderMethod == null) {
+      getHeaderMethod = KafkaUtils.lookupGetHeaderMethod(
+          source.getEntity().getClass().getClassLoader(),
+          VERSION_HEADER_KEY
+      );
+    }
+
+    try {
+      byte[] versionHeader = (byte[]) getHeaderMethod.invoke(source.getEntity());
+      if (versionHeader != null) {
+        int version =
+            ByteBuffer.wrap(versionHeader).order(ByteOrder.LITTLE_ENDIAN).getInt();
+        if (version == OPENTELEMETRY_FORMAT_VERSION) {
+          return OPEN_TELEMETRY;
+        }
+      }
+    }
+    catch (Throwable t) {
+      // assume input is opencensus if something went wrong
+    }
+    return OPEN_CENSUS;
+  }
+
+  @Override
+  public CloseableIterator<InputRowListPlusRawValues> sample() throws IOException
+  {
+    try (CloseableIterator<InputRow> iterator = read()) {
+      return iterator.map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
+    }
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
@@ -132,8 +132,6 @@ public class HybridProtobufReader implements InputEntityReader
   @Override
   public CloseableIterator<InputRowListPlusRawValues> sample() throws IOException
   {
-    try (CloseableIterator<InputRow> iterator = read()) {
-      return iterator.map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
-    }
+    return read().map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
   }
 }

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
@@ -35,9 +35,6 @@ import java.lang.invoke.MethodHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import static org.apache.druid.data.input.opencensus.protobuf.HybridProtobufReader.ProtobufReader.OPENCENSUS;
-import static org.apache.druid.data.input.opencensus.protobuf.HybridProtobufReader.ProtobufReader.OPENTELEMETRY;
-
 public class HybridProtobufReader implements InputEntityReader
 {
   private static final String VERSION_HEADER_KEY = "v";
@@ -52,7 +49,8 @@ public class HybridProtobufReader implements InputEntityReader
 
   private volatile MethodHandle getHeaderMethod = null;
 
-  enum ProtobufReader {
+  enum ProtobufReader
+  {
     OPENCENSUS,
     OPENTELEMETRY
   }
@@ -82,7 +80,7 @@ public class HybridProtobufReader implements InputEntityReader
 
   public InputEntityReader newReader(ProtobufReader which)
   {
-    switch(which) {
+    switch (which) {
       case OPENTELEMETRY:
         return new OpenTelemetryMetricsProtobufReader(
             dimensionsSpec,
@@ -121,14 +119,14 @@ public class HybridProtobufReader implements InputEntityReader
         int version =
             ByteBuffer.wrap(versionHeader).order(ByteOrder.LITTLE_ENDIAN).getInt();
         if (version == OPENTELEMETRY_FORMAT_VERSION) {
-          return OPENTELEMETRY;
+          return ProtobufReader.OPENTELEMETRY;
         }
       }
     }
     catch (Throwable t) {
       // assume input is opencensus if something went wrong
     }
-    return OPENCENSUS;
+    return ProtobufReader.OPENCENSUS;
   }
 
   @Override

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -24,17 +24,12 @@ import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
-import org.apache.druid.data.input.KafkaUtils;
 import org.apache.druid.data.input.impl.ByteEntity;
-import org.apache.druid.data.input.opentelemetry.protobuf.OpenTelemetryMetricsProtobufReader;
 import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.lang.invoke.MethodHandle;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Objects;
 
 public class OpenCensusProtobufInputFormat implements InputFormat
@@ -49,8 +44,6 @@ public class OpenCensusProtobufInputFormat implements InputFormat
   private final String valueDimension;
   private final String metricLabelPrefix;
   private final String resourceLabelPrefix;
-
-  private volatile MethodHandle getHeaderMethod = null;
 
   public OpenCensusProtobufInputFormat(
       @JsonProperty("metricDimension") String metricDimension,
@@ -85,7 +78,7 @@ public class OpenCensusProtobufInputFormat implements InputFormat
       wrapper.setEntity((ByteEntity) source);
       settableEntity = wrapper;
     }
-    return new OpenCensusProtobufReader(
+    return new HybridProtobufReader(
         inputRowSchema.getDimensionsSpec(),
         settableEntity,
         metricDimension,

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -74,9 +74,18 @@ public class OpenCensusProtobufInputFormat implements InputFormat
   @Override
   public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
   {
+    SettableByteEntity<? extends ByteEntity> settableEntity;
+    if (source instanceof SettableByteEntity) {
+      settableEntity = (SettableByteEntity<? extends ByteEntity>) source;
+    }
+    else {
+      SettableByteEntity<ByteEntity> wrapper = new SettableByteEntity<>();
+      wrapper.setEntity((ByteEntity) source);
+      settableEntity = wrapper;
+    }
     return new OpenCensusProtobufReader(
         inputRowSchema.getDimensionsSpec(),
-        (SettableByteEntity<? extends ByteEntity>) source,
+        settableEntity,
         metricDimension,
         valueDimension,
         metricLabelPrefix,

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -70,8 +70,7 @@ public class OpenCensusProtobufInputFormat implements InputFormat
     SettableByteEntity<? extends ByteEntity> settableEntity;
     if (source instanceof SettableByteEntity) {
       settableEntity = (SettableByteEntity<? extends ByteEntity>) source;
-    }
-    else {
+    } else {
       SettableByteEntity<ByteEntity> wrapper = new SettableByteEntity<>();
       wrapper.setEntity((ByteEntity) source);
       settableEntity = wrapper;

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -74,6 +74,8 @@ public class OpenCensusProtobufInputFormat implements InputFormat
   @Override
   public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
   {
+    // Sampler passes a KafkaRecordEntity directly, while the normal code path wraps the same entity in a
+    // SettableByteEntity
     SettableByteEntity<? extends ByteEntity> settableEntity;
     if (source instanceof SettableByteEntity) {
       settableEntity = (SettableByteEntity<? extends ByteEntity>) source;

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -37,8 +37,6 @@ public class OpenCensusProtobufInputFormat implements InputFormat
   private static final String DEFAULT_METRIC_DIMENSION = "name";
   private static final String DEFAULT_RESOURCE_PREFIX = "resource.";
   private static final String DEFAULT_VALUE_DIMENSION = "value";
-  private static final String VERSION_HEADER_KEY = "v";
-  private static final int OPENTELEMETRY_FORMAT_VERSION = 1;
 
   private final String metricDimension;
   private final String valueDimension;

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
@@ -110,7 +110,6 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
         parseSpec.getDimensionsSpec(),
         settableByteEntity,
         metricDimension,
-        null,
         metricLabelPrefix,
         resourceLabelPrefix
     ).readAsList();

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
@@ -26,6 +26,7 @@ import org.apache.druid.data.input.ByteBufferInputRowParser;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.ParseSpec;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
@@ -104,10 +104,13 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
   @Override
   public List<InputRow> parseBatch(ByteBuffer input)
   {
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(input));
     return new OpenCensusProtobufReader(
         parseSpec.getDimensionsSpec(),
-        new ByteEntity(input),
+        settableByteEntity,
         metricDimension,
+        null,
         metricLabelPrefix,
         resourceLabelPrefix
     ).readAsList();

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -19,8 +19,6 @@
 
 package org.apache.druid.data.input.opencensus.protobuf;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -50,7 +48,6 @@ import java.nio.ByteOrder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -81,6 +81,7 @@ public class OpenCensusProtobufReader implements InputEntityReader
   {
     void addRow(long millis, String metricName, Object value);
   }
+
   @Override
   public CloseableIterator<InputRow> read()
   {

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -24,6 +24,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
 import io.opencensus.proto.metrics.v1.LabelKey;
 import io.opencensus.proto.metrics.v1.Metric;
@@ -110,7 +111,7 @@ public class OpenCensusProtobufReader implements InputEntityReader
       buffer.position(buffer.limit());
       return rows;
     }
-    catch (IOException e) {
+    catch (InvalidProtocolBufferException e) {
       throw new ParseException(null, e, "Protobuf message could not be parsed");
     }
   }

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -36,6 +36,7 @@ import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.CloseableIterators;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -42,7 +42,6 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.utils.CollectionUtils;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -225,10 +224,8 @@ public class OpenCensusProtobufReader implements InputEntityReader
   }
 
   @Override
-  public CloseableIterator<InputRowListPlusRawValues> sample() throws IOException
+  public CloseableIterator<InputRowListPlusRawValues> sample()
   {
-    try (CloseableIterator<InputRow> iterator = read()) {
-      return iterator.map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
-    }
+    return read().map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
   }
 }

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -24,7 +24,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
 import io.opencensus.proto.metrics.v1.LabelKey;
 import io.opencensus.proto.metrics.v1.Metric;

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
@@ -43,9 +43,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -99,11 +97,6 @@ public class OpenCensusProtobufReaderTest
   private static final Header HEADERV1 = new RecordHeader("v", V0_HEADER_BYTES);
   private static final Headers HEADERS = new RecordHeaders(new Header[]{HEADERV1});
 
-
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Before
   public void setUp()
   {
@@ -138,8 +131,8 @@ public class OpenCensusProtobufReaderTest
 
 
     MetricsData metricsData = metricsDataBuilder.build();
-    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(
-        TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1, null, metricsData.toByteArray(), HEADERS, Optional.empty());
+    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1,
+        null, metricsData.toByteArray(), HEADERS, Optional.empty());
     OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat(
         "metric.name",
         null,
@@ -182,8 +175,8 @@ public class OpenCensusProtobufReaderTest
       .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
 
     MetricsData metricsData = metricsDataBuilder.build();
-    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(
-        TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1, null, metricsData.toByteArray(), HEADERS, Optional.empty());
+    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1,
+        null, metricsData.toByteArray(), HEADERS, Optional.empty());
     OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
         null,
         "descriptor.",
@@ -248,8 +241,8 @@ public class OpenCensusProtobufReaderTest
       .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_FOO_VAL).build());
 
     MetricsData metricsData = metricsDataBuilder.build();
-    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(
-        TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1, null, metricsData.toByteArray(), HEADERS, Optional.empty());
+    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1,
+        null, metricsData.toByteArray(), HEADERS, Optional.empty());
     OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
         null,
          "descriptor.",
@@ -311,8 +304,8 @@ public class OpenCensusProtobufReaderTest
         )).build();
 
     MetricsData metricsData = metricsDataBuilder.build();
-    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(
-        TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1, null, metricsData.toByteArray(), HEADERS, Optional.empty());
+    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1,
+        null, metricsData.toByteArray(), HEADERS, Optional.empty());
     OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
         null,
         "descriptor.",
@@ -344,8 +337,8 @@ public class OpenCensusProtobufReaderTest
   public void testInvalidProtobuf() throws IOException
   {
     byte[] invalidProtobuf = new byte[] {0x00, 0x01};
-    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(
-        TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1, null, invalidProtobuf, HEADERS, Optional.empty());
+    ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>(TOPIC, PARTITION, OFFSET, TS, TSTYPE, -1, -1,
+        null, invalidProtobuf, HEADERS, Optional.empty());
     OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
         null,
         "descriptor.",

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
@@ -361,11 +361,6 @@ public class OpenCensusProtobufReaderTest
     entity.setEntity(new KafkaRecordEntity(consumerRecord));
     try (CloseableIterator<InputRow> rows = reader.read()) {
       Assert.assertThrows(ParseException.class, () -> rows.hasNext());
-    }
-    // Can't re-use the entity after the exception above is thrown because {@link SettableByteEntity#open()} can't be
-    // called twice on the same input stream.
-    entity.setEntity(new KafkaRecordEntity(consumerRecord));
-    try (CloseableIterator<InputRow> rows = reader.read()) {
       Assert.assertThrows(ParseException.class, () -> rows.next());
     }
   }

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
@@ -361,6 +361,11 @@ public class OpenCensusProtobufReaderTest
     entity.setEntity(new KafkaRecordEntity(consumerRecord));
     try (CloseableIterator<InputRow> rows = reader.read()) {
       Assert.assertThrows(ParseException.class, () -> rows.hasNext());
+    }
+    // Can't re-use the entity after the exception above is thrown because {@link SettableByteEntity#open()} can't be
+    // called twice on the same input stream.
+    entity.setEntity(new KafkaRecordEntity(consumerRecord));
+    try (CloseableIterator<InputRow> rows = reader.read()) {
       Assert.assertThrows(ParseException.class, () -> rows.next());
     }
   }

--- a/extensions-contrib/opencensus-extensions/src/test/resources/log4j2.xml
+++ b/extensions-contrib/opencensus-extensions/src/test/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<Configuration status="INFO">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+    <Logger level="info" name="org.apache.druid" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
+  </Loggers>
+</Configuration>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -73,6 +73,12 @@
             <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.druid</groupId>
+            <artifactId>druid-indexing-service</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- test -->
         <dependency>
             <groupId>junit</groupId>

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
@@ -64,6 +64,8 @@ public class OpenTelemetryMetricsProtobufInputFormat implements InputFormat
   @Override
   public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
   {
+    // Sampler passes a KafkaRecordEntity directly, while the normal code path wraps the same entity in a
+    // SettableByteEntity
     SettableByteEntity<? extends ByteEntity> settableEntity;
     if (source instanceof SettableByteEntity) {
       settableEntity = (SettableByteEntity<? extends ByteEntity>) source;

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
@@ -69,8 +69,7 @@ public class OpenTelemetryMetricsProtobufInputFormat implements InputFormat
     SettableByteEntity<? extends ByteEntity> settableEntity;
     if (source instanceof SettableByteEntity) {
       settableEntity = (SettableByteEntity<? extends ByteEntity>) source;
-    }
-    else {
+    } else {
       SettableByteEntity<ByteEntity> wrapper = new SettableByteEntity<>();
       wrapper.setEntity((ByteEntity) source);
       settableEntity = wrapper;

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
@@ -25,6 +25,7 @@ import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.StringUtils;
 
 import java.io.File;
@@ -65,7 +66,7 @@ public class OpenTelemetryMetricsProtobufInputFormat implements InputFormat
   {
     return new OpenTelemetryMetricsProtobufReader(
             inputRowSchema.getDimensionsSpec(),
-            (ByteEntity) source,
+            (SettableByteEntity<? extends ByteEntity>) source,
             metricDimension,
             valueDimension,
             metricAttributePrefix,

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
@@ -64,9 +64,18 @@ public class OpenTelemetryMetricsProtobufInputFormat implements InputFormat
   @Override
   public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
   {
+    SettableByteEntity<? extends ByteEntity> settableEntity;
+    if (source instanceof SettableByteEntity) {
+      settableEntity = (SettableByteEntity<? extends ByteEntity>) source;
+    }
+    else {
+      SettableByteEntity<ByteEntity> wrapper = new SettableByteEntity<>();
+      wrapper.setEntity((ByteEntity) source);
+      settableEntity = wrapper;
+    }
     return new OpenTelemetryMetricsProtobufReader(
             inputRowSchema.getDimensionsSpec(),
-            (SettableByteEntity<? extends ByteEntity>) source,
+            settableEntity,
             metricDimension,
             valueDimension,
             metricAttributePrefix,

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -154,7 +154,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       case HISTOGRAM:
       case SUMMARY:
       default:
-        log.trace("Metric type {} is not supported", metric.getDataCase());
+        log.trace("Metric type %s is not supported", metric.getDataCase());
         inputRows = Collections.emptyList();
 
     }

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -41,6 +41,7 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -99,9 +100,9 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
   List<InputRow> readAsList()
   {
     try {
-      return parseMetricsData(MetricsData.parseFrom(source.getEntity().getBuffer()));
+      return parseMetricsData(MetricsData.parseFrom(source.open()));
     }
-    catch (InvalidProtocolBufferException e) {
+    catch (IOException e) {
       throw new ParseException(null, e, "Protobuf message could not be parsed");
     }
   }

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -19,11 +19,8 @@
 
 package org.apache.druid.data.input.opentelemetry.protobuf;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.protobuf.InvalidProtocolBufferException;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.MetricsData;
@@ -45,7 +42,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -34,6 +34,7 @@ import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.CloseableIterators;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
@@ -53,7 +54,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
 {
   private static final Logger log = new Logger(OpenTelemetryMetricsProtobufReader.class);
 
-  private final ByteEntity source;
+  private final SettableByteEntity<? extends ByteEntity> source;
   private final String metricDimension;
   private final String valueDimension;
   private final String metricAttributePrefix;
@@ -62,7 +63,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
 
   public OpenTelemetryMetricsProtobufReader(
       DimensionsSpec dimensionsSpec,
-      ByteEntity source,
+      SettableByteEntity<? extends ByteEntity> source,
       String metricDimension,
       String valueDimension,
       String metricAttributePrefix,
@@ -98,7 +99,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
   List<InputRow> readAsList()
   {
     try {
-      return parseMetricsData(MetricsData.parseFrom(source.getBuffer()));
+      return parseMetricsData(MetricsData.parseFrom(source.getEntity().getBuffer()));
     }
     catch (InvalidProtocolBufferException e) {
       throw new ParseException(null, e, "Protobuf message could not be parsed");

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -23,6 +23,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.MetricsData;
@@ -107,7 +108,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       buffer.position(buffer.limit());
       return rows;
     }
-    catch (IOException e) {
+    catch (InvalidProtocolBufferException e) {
       throw new ParseException(null, e, "Protobuf message could not be parsed");
     }
   }

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -82,19 +82,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
   @Override
   public CloseableIterator<InputRow> read()
   {
-    Supplier<Iterator<InputRow>> supplier = Suppliers.memoize(() -> readAsList().iterator());
-    return CloseableIterators.withEmptyBaggage(new Iterator<InputRow>() {
-      @Override
-      public boolean hasNext()
-      {
-        return supplier.get().hasNext();
-      }
-      @Override
-      public InputRow next()
-      {
-        return supplier.get().next();
-      }
-    });
+    return CloseableIterators.withEmptyBaggage(readAsList().iterator());
   }
 
   List<InputRow> readAsList()

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -41,7 +41,6 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -229,10 +228,8 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
   }
 
   @Override
-  public CloseableIterator<InputRowListPlusRawValues> sample() throws IOException
+  public CloseableIterator<InputRowListPlusRawValues> sample()
   {
-    try (CloseableIterator<InputRow> iterator = read()) {
-      return iterator.map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
-    }
+    return read().map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
   }
 }

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -370,9 +370,6 @@ public class OpenTelemetryMetricsProtobufReaderTest
         "custom."
     ).read()) {
       Assert.assertThrows(ParseException.class, () -> rows.hasNext());
-      // Can't re-use the entity after the exception above is thrown because {@link SettableByteEntity#open()} can't be
-      // called twice on the same input stream.
-      settableByteEntity.setEntity(new ByteEntity(invalidProtobuf));
       Assert.assertThrows(ParseException.class, () -> rows.next());
     } catch (IOException e) {
       // Comes from the implicit call to close. Ignore

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.junit.Assert;
@@ -110,9 +111,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -145,9 +148,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -205,9 +210,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -262,9 +269,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
             "custom." + RESOURCE_ATTRIBUTE_COUNTRY
     )).build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpecWithExclusions,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -315,9 +324,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -347,9 +358,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
   public void testInvalidProtobuf()
   {
     byte[] invalidProtobuf = new byte[] {0x00, 0x01};
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(invalidProtobuf));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(invalidProtobuf),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -370,9 +383,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -371,7 +371,8 @@ public class OpenTelemetryMetricsProtobufReaderTest
     ).read()) {
       Assert.assertThrows(ParseException.class, () -> rows.hasNext());
       Assert.assertThrows(ParseException.class, () -> rows.next());
-    } catch (IOException e) {
+    }
+    catch (IOException e) {
       // Comes from the implicit call to close. Ignore
     }
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes [OBSDATA-483](https://confluentinc.atlassian.net/browse/OBSDATA-483) 


<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

In our deployments, metrics emitted from a Kafka topic can be a mix of formats between OpenTelemetry and OpenCensus formats. Up until version 24.0.0, the entity passed as input to the format readers could be cast as `ByteEntity` and have the protobuf message parsed directly from the `ByteBuffer` of this entity. However with druid-24.0.0 a wrapper class `SettableByteEntity` is introduced and now the classes in the opencensus and opentelemtry extensions need to be adapted to handle `SettableByteEntity` objects that use composition instead of inheritance in relation to `ByteEntity` objects. 

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR

* Since we need to choose during runtime the appropriate reader, a new class `HybridProtobufReader` is introduced that can delegate reading and parsing of the input entity to appropriate reader (OpenCensus or OpenTelemetry)
* Given that samplers from the UI still pass a `KafkaRecordEntity` directly and not a `SettableByteEntity` the code is adapted for now to distinguish between the two inputs by checking the instance of the input (a potential near future fix is to adapt samplers to also use `SettableByteEntity`)
* Advancement of the position of the entity buffer is done explicitly since the protobuf parser does not manipulate the position of the `ByteBuffer` that is passed to it as an arguemnt. 
* Logging of messages is enabled in tests for opencensus
* Adaptation of current tests seems sufficient at this point. Eventually it'd be good to add integration tests that ingest protobuf messages from Kafka with a mix of OpenCensus and OpenTelemetry formats. 

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.


[OBSDATA-483]: https://confluentinc.atlassian.net/browse/OBSDATA-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OBSDATA-483]: https://confluentinc.atlassian.net/browse/OBSDATA-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ