### PR TITLE
Fixing CI/CD in 24.0.0 upgrade branch

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -129,5 +129,5 @@ blocks:
         - name: "Other Tests"
           env_vars:
             - name: MAVEN_PROJECTS
-              value: '!server,!processing,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-contrib/confluent-extensions'
+              value: '!server,!processing,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-contrib/confluent-extensions,!integration-tests-ex/cases'
           commands: *run_tests

--- a/extensions-contrib/confluent-extensions/src/test/java/io/confluent/druid/transform/ExtractTransformTest.java
+++ b/extensions-contrib/confluent-extensions/src/test/java/io/confluent/druid/transform/ExtractTransformTest.java
@@ -28,7 +28,7 @@ public class ExtractTransformTest
   private static final MapInputRowParser PARSER = new MapInputRowParser(
       new TimeAndDimsParseSpec(
           new TimestampSpec("t", "auto", DateTimes.of("2020-01-01")),
-          new DimensionsSpec( DimensionsSpec.getDefaultSchemas(ImmutableList.of("topic", "tenant")))
+          new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("topic", "tenant")))
       )
   );
 


### PR DESCRIPTION
Fixing CI/CD failure.
Excluding the integration test module to be in alignment with upstream as discussed in [this](https://confluent.slack.com/archives/C02E0T1LKFB/p1666992483088289) slack thread.
