### PR TITLE
DP-9370 - use cc-service-bot to manage Semaphore project

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,11 @@
+name: druid
+lang: unknown
+lang_version: unknown
+git:
+  enable: true
+github:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_enable: false
+  branches: []


### PR DESCRIPTION
This PR onboards the repo to cc-service-bot for managing its Semaphore project via code.