### PR TITLE
DP-9632: remediate duplicate Semaphore workflows

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -8,7 +8,7 @@ github:
 semaphore:
   enable: true
   pipeline_enable: false
-  branches: []
-  triggers:
-  - branches
-  - tags
+  branches:
+  - master
+  - /^.*-confluent$/
+  - /^.*\..*\..*$/

--- a/service.yml
+++ b/service.yml
@@ -8,3 +8,7 @@ github:
 semaphore:
   enable: true
   pipeline_enable: false
+  branches: []
+  triggers:
+  - branches
+  - tags

--- a/service.yml
+++ b/service.yml
@@ -11,4 +11,3 @@ semaphore:
   branches:
   - master
   - /^.*-confluent$/
-  - /^.*\..*\..*$/

--- a/service.yml
+++ b/service.yml
@@ -8,4 +8,3 @@ github:
 semaphore:
   enable: true
   pipeline_enable: false
-  branches: []


### PR DESCRIPTION
This repo currently has a Semaphore project that triggers workflows on both pull requests and all branches. This configuration results in 2 workflow executions when a pull request is created or updated. 

This pull request changes the project configuration to no longer trigger workflows on the pull request event. It will continue to trigger workflows on all tags and branches. The branch triggers will be reported in pull request checks. This configuration was chosen because the default branch in this repo is not master, and it looks like there are other persistent branches.