### PR TITLE
[Metrics-4776] OpenTelemetry Extensions - Upgrade otel-proto version

### DIFF
--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
@@ -63,8 +63,8 @@ public class OpenCensusProtobufReaderTest
   public static final String RESOURCE_ATTRIBUTE_ENV = "env";
   public static final String RESOURCE_ATTRIBUTE_VALUE_DEVEL = "devel";
 
-  public static final String INSTRUMENTATION_LIBRARY_NAME = "mock-instr-lib";
-  public static final String INSTRUMENTATION_LIBRARY_VERSION = "1.0";
+  public static final String INSTRUMENTATION_SCOPE_NAME = "mock-instr-lib";
+  public static final String INSTRUMENTATION_SCOPE_VERSION = "1.0";
 
   public static final String METRIC_ATTRIBUTE_COLOR = "color";
   public static final String METRIC_ATTRIBUTE_VALUE_RED = "red";
@@ -75,7 +75,7 @@ public class OpenCensusProtobufReaderTest
   private final MetricsData.Builder metricsDataBuilder = MetricsData.newBuilder();
 
   private final Metric.Builder metricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
-      .addInstrumentationLibraryMetricsBuilder()
+      .addScopeMetricsBuilder()
       .addMetricsBuilder();
 
   private final DimensionsSpec dimensionsSpec = new DimensionsSpec(ImmutableList.of(
@@ -109,10 +109,10 @@ public class OpenCensusProtobufReaderTest
 
     metricsDataBuilder
       .getResourceMetricsBuilder(0)
-      .getInstrumentationLibraryMetricsBuilder(0)
-      .getInstrumentationLibraryBuilder()
-      .setName(INSTRUMENTATION_LIBRARY_NAME)
-      .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+      .getScopeMetricsBuilder(0)
+      .getScopeBuilder()
+      .setName(INSTRUMENTATION_SCOPE_NAME)
+      .setVersion(INSTRUMENTATION_SCOPE_VERSION);
 
   }
 
@@ -215,7 +215,7 @@ public class OpenCensusProtobufReaderTest
 
     // Create Second Metric
     Metric.Builder gaugeMetricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
-        .addInstrumentationLibraryMetricsBuilder()
+        .addScopeMetricsBuilder()
         .addMetricsBuilder();
 
     metricsDataBuilder.getResourceMetricsBuilder(1)
@@ -226,10 +226,10 @@ public class OpenCensusProtobufReaderTest
           .build());
 
     metricsDataBuilder.getResourceMetricsBuilder(1)
-      .getInstrumentationLibraryMetricsBuilder(0)
-      .getInstrumentationLibraryBuilder()
-      .setName(INSTRUMENTATION_LIBRARY_NAME)
-      .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+      .getScopeMetricsBuilder(0)
+      .getScopeBuilder()
+      .setName(INSTRUMENTATION_SCOPE_NAME)
+      .setVersion(INSTRUMENTATION_SCOPE_VERSION);
 
     gaugeMetricBuilder.setName("example_gauge")
       .getGaugeBuilder()

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -128,7 +128,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
                     }
                   },
                   HashMap::putAll);
-          return resourceMetrics.getInstrumentationLibraryMetricsList()
+          return resourceMetrics.getScopeMetricsList()
               .stream()
               .flatMap(libraryMetrics -> libraryMetrics.getMetricsList()
                   .stream()

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -130,7 +130,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
                   HashMap::putAll);
           return resourceMetrics.getScopeMetricsList()
               .stream()
-              .flatMap(libraryMetrics -> libraryMetrics.getMetricsList()
+              .flatMap(scopeMetrics -> scopeMetrics.getMetricsList()
                   .stream()
                   .flatMap(metric -> parseMetric(metric, resourceAttributes).stream()));
         })

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
@@ -22,11 +22,11 @@ package org.apache.druid.data.input.opentelemetry.protobuf;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
-import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.MetricsData;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
 import io.opentelemetry.proto.resource.v1.Resource;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
@@ -95,8 +95,8 @@ public class OpenTelemetryBenchmark
       }
 
       for (int j = 0; j < instrumentationLibraryCount; j++) {
-        InstrumentationLibraryMetrics.Builder instrumentationLibraryMetricsBuilder =
-            resourceMetricsBuilder.addInstrumentationLibraryMetricsBuilder();
+        ScopeMetrics.Builder instrumentationLibraryMetricsBuilder =
+            resourceMetricsBuilder.addScopeMetricsBuilder();
 
         for (int k = 0; k < metricsCount; k++) {
           Metric.Builder metricBuilder = instrumentationLibraryMetricsBuilder.addMetricsBuilder();

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
@@ -58,7 +58,7 @@ public class OpenTelemetryBenchmark
   private int resourceMetricCount = 1;
 
   @Param(value = {"1"})
-  private int instrumentationLibraryCount = 1;
+  private int instrumentationScopeCount = 1;
 
   @Param(value = {"1", "2", "4", "8" })
   private int metricsCount = 1;
@@ -94,12 +94,12 @@ public class OpenTelemetryBenchmark
         resourceAttributeBuilder.setValue(AnyValue.newBuilder().setStringValue("resource.label_value"));
       }
 
-      for (int j = 0; j < instrumentationLibraryCount; j++) {
-        ScopeMetrics.Builder instrumentationLibraryMetricsBuilder =
+      for (int j = 0; j < instrumentationScopeCount; j++) {
+        ScopeMetrics.Builder scopeMetricsBuilder =
             resourceMetricsBuilder.addScopeMetricsBuilder();
 
         for (int k = 0; k < metricsCount; k++) {
-          Metric.Builder metricBuilder = instrumentationLibraryMetricsBuilder.addMetricsBuilder();
+          Metric.Builder metricBuilder = scopeMetricsBuilder.addMetricsBuilder();
           metricBuilder.setName("io.confluent.domain/such/good/metric/wow");
 
           for (int l = 0; l < dataPointCount; l++) {

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -53,8 +53,8 @@ public class OpenTelemetryMetricsProtobufReaderTest
   public static final String RESOURCE_ATTRIBUTE_ENV = "env";
   public static final String RESOURCE_ATTRIBUTE_VALUE_DEVEL = "devel";
 
-  public static final String INSTRUMENTATION_LIBRARY_NAME = "mock-instr-lib";
-  public static final String INSTRUMENTATION_LIBRARY_VERSION = "1.0";
+  public static final String INSTRUMENTATION_SCOPE_NAME = "mock-instr-lib";
+  public static final String INSTRUMENTATION_SCOPE_VERSION = "1.0";
 
   public static final String METRIC_ATTRIBUTE_COLOR = "color";
   public static final String METRIC_ATTRIBUTE_VALUE_RED = "red";
@@ -92,8 +92,8 @@ public class OpenTelemetryMetricsProtobufReaderTest
         .getResourceMetricsBuilder(0)
         .getScopeMetricsBuilder(0)
         .getScopeBuilder()
-        .setName(INSTRUMENTATION_LIBRARY_NAME)
-        .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+        .setName(INSTRUMENTATION_SCOPE_NAME)
+        .setVersion(INSTRUMENTATION_SCOPE_VERSION);
 
   }
 
@@ -197,8 +197,8 @@ public class OpenTelemetryMetricsProtobufReaderTest
     metricsDataBuilder.getResourceMetricsBuilder(1)
         .getScopeMetricsBuilder(0)
         .getScopeBuilder()
-        .setName(INSTRUMENTATION_LIBRARY_NAME)
-        .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+        .setName(INSTRUMENTATION_SCOPE_NAME)
+        .setVersion(INSTRUMENTATION_SCOPE_VERSION);
 
     gaugeMetricBuilder.setName("example_gauge")
         .getGaugeBuilder()

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -381,7 +381,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
   public void testInvalidMetricType()
   {
     metricBuilder
-        .setName("deprecated_intsum")
+        .setName("unsupported_histogram_metric")
         .getExponentialHistogramBuilder()
         .addDataPointsBuilder()
         .setTimeUnixNano(TIMESTAMP);

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -65,7 +65,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
   private final MetricsData.Builder metricsDataBuilder = MetricsData.newBuilder();
 
   private final Metric.Builder metricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
-      .addInstrumentationLibraryMetricsBuilder()
+      .addScopeMetricsBuilder()
       .addMetricsBuilder();
 
   private final DimensionsSpec dimensionsSpec = new DimensionsSpec(ImmutableList.of(
@@ -90,8 +90,8 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     metricsDataBuilder
         .getResourceMetricsBuilder(0)
-        .getInstrumentationLibraryMetricsBuilder(0)
-        .getInstrumentationLibraryBuilder()
+        .getScopeMetricsBuilder(0)
+        .getScopeBuilder()
         .setName(INSTRUMENTATION_LIBRARY_NAME)
         .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
 
@@ -184,7 +184,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     // Create Second Metric
     Metric.Builder gaugeMetricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
-        .addInstrumentationLibraryMetricsBuilder()
+        .addScopeMetricsBuilder()
         .addMetricsBuilder();
 
     metricsDataBuilder.getResourceMetricsBuilder(1)
@@ -195,8 +195,8 @@ public class OpenTelemetryMetricsProtobufReaderTest
             .build());
 
     metricsDataBuilder.getResourceMetricsBuilder(1)
-        .getInstrumentationLibraryMetricsBuilder(0)
-        .getInstrumentationLibraryBuilder()
+        .getScopeMetricsBuilder(0)
+        .getScopeBuilder()
         .setName(INSTRUMENTATION_LIBRARY_NAME)
         .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
 
@@ -382,7 +382,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
   {
     metricBuilder
         .setName("deprecated_intsum")
-        .getIntSumBuilder()
+        .getExponentialHistogramBuilder()
         .addDataPointsBuilder()
         .setTimeUnixNano(TIMESTAMP);
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <repoOrgId>apache.snapshots</repoOrgId>
         <repoOrgName>Apache Snapshot Repository</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/snapshots</repoOrgUrl>
-        <opentelemetry.proto.version>0.11.0-alpha</opentelemetry.proto.version>
+        <opentelemetry.proto.version>0.19.0-alpha</opentelemetry.proto.version>
 
         <!-- Allow the handful of flaky tests with transient failures to pass. -->
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

- Upgrade OpenTelemetry-Proto from `0.11.0` to version [0.19.0](https://github.com/open-telemetry/opentelemetry-proto/releases)
  -  Removed deprecated field `InstrumentationLibrary` and used wire-compatible `InstrumentationScope` ([Reference](https://github.com/open-telemetry/opentelemetry-proto/pull/342/files))
  - Removed reference to deprecated `INT_SUM` in test (Removed in version [0.12.0](https://github.com/open-telemetry/opentelemetry-proto/pull/342/files))

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `OpenTelemetryMetricsProtobufReader.java`


<hr>
 
### Testing:

- Ran the tests for `extensions-contrib/opencensus-extensions`, `extensions-contrib/opentelemetry-extensions`
- end to end testing in progress

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
