### PR TITLE
[CMRR-128]: druid jose4j extension

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -627,6 +627,8 @@
                                         <argument>io.confluent.druid.extensions:confluent-extensions</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:opentelemetry-emitter</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:druid-jwt-extensions</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/docs/development/extensions-contrib/druid-jwt-extensions.md
+++ b/docs/development/extensions-contrib/druid-jwt-extensions.md
@@ -1,0 +1,76 @@
+---
+id: druid-jwt-extensions
+title: "Druid JWT Extension"
+---
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+Apache Druid Extension to enable Authentication for Druid Processes using JWT. This extension adds an Authenticator
+which decodes and verifies JWT.
+To load the extension, [include](../../development/extensions.md#loading-extensions) `druid-jwt-extensions` in the
+extensions load list.
+
+## Configuration
+
+### Creating an Authenticator
+
+```
+druid.auth.authenticatorChain=["MyJwtAuthenticator"]
+
+druid.auth.authenticator.MyJwtAuthenticator.type=jwt_jwks
+```
+
+To use the JWT authenticator, add an authenticator with type `jwt_jwks` to the authenticatorChain. The example above
+uses the name "MyJwtAuthenticator" for the Authenticator.
+
+Configuration of the named authenticator is assigned through properties with the form:
+
+```
+druid.auth.authenticator.<authenticatorName>.<authenticatorProperty>
+```
+
+The configuration examples in the rest of this document will use "jwt" as the name of the authenticator being
+configured.
+
+### Properties
+
+| Property                                           | Description                                                     | Default | required                                        |
+|----------------------------------------------------|-----------------------------------------------------------------|---------|-------------------------------------------------|
+| `druid.auth.authenticator.jwt.audience`            | Recipients for which the JWT is intended.                       | none    | If `aud` claim is present in JWT, it's required |
+| `druid.auth.authenticator.jwt.issuer`              | Issuer of the JWT                                               | none    | yes                                             |
+| `druid.auth.authenticator.jwt.jwksUri`             | JWKS endpoint provided by identity provider                     | none    | yes                                             |
+| `druid.auth.authenticator.jwt.jwtGroupIdentityMap` | Map JWT custom `groups` Claim to identity used in authorization | none    | No                                              |
+| `druid.auth.authenticator.jwt.authorizerName`      | Authorizer that requests should be directed to                  | none    | Yes                                             |
+
+Example configuration of an authenticator
+```
+druid.auth.authenticator.jwt.audience=["audA", "audB"]
+druid.auth.authenticator.jwt.issuer=https://--YOUR DOMAIN----/
+druid.auth.authenticator.jwt.jwksUri=https://--YOUR DOMAIN----/.well-known/jwks.json
+druid.auth.authenticator.jwt.jwtGroupIdentityMap={"groupA": "authZuserA"}
+druid.auth.authenticator.jwt.authorizerName=basic
+```
+
+#### druid.auth.authenticator.jwt.jwtGroupIdentityMap
+This property maps JWT custom `groups` claim to the identity used in authorization. Ideally every Caller/Client service would have a unique `group`
+so the authenticator would uniquely identify the caller. For a set of users within same group, this property would map
+those JWTs to same identity in the authorizer. If property is not set, JWT `sub` claim is used as the identity in the authorizer. 
+
+

--- a/extensions-contrib/druid-jwt-extensions/pom.xml
+++ b/extensions-contrib/druid-jwt-extensions/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.druid.extensions.contrib</groupId>
+  <artifactId>druid-jwt-extensions</artifactId>
+  <name>druid-jwt-extensions</name>
+  <description>druid-jwt-extensions</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <parent>
+    <groupId>org.apache.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>24.0.2</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-core</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bitbucket.b_c</groupId>
+      <artifactId>jose4j</artifactId>
+      <version>0.9.2</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/AuthUtils.java
+++ b/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/AuthUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.jwt;
+
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+
+public class AuthUtils
+{
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+
+  @Nullable
+  public static String getBearerTokenFromHttpReq(HttpServletRequest httpReq)
+  {
+    String authHeader = httpReq.getHeader(AUTHORIZATION_HEADER);
+
+    if (authHeader != null && authHeader.startsWith("Bearer")) {
+      // the RFC for bearer tokens specifies that it could be one or more leading spaces
+      // https://datatracker.ietf.org/doc/rfc6750/
+      // credentials = "Bearer" 1*SP b64token
+      return authHeader.substring(6).trim();
+    }
+    return null;
+  }
+
+}

--- a/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/DruidJwtModule.java
+++ b/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/DruidJwtModule.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.jwt;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import org.apache.druid.initialization.DruidModule;
+
+import java.util.List;
+
+public class DruidJwtModule implements DruidModule
+{
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.of(new SimpleModule("DruidJwtModule").registerSubtypes(JwtJwksAuthenticator.class));
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+  }
+}

--- a/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/InvalidGroupsClaimException.java
+++ b/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/InvalidGroupsClaimException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.jwt;
+
+import org.jose4j.jwt.MalformedClaimException;
+
+public class InvalidGroupsClaimException extends MalformedClaimException
+{
+  public InvalidGroupsClaimException(String message)
+  {
+    super(message);
+  }
+
+  public InvalidGroupsClaimException(String message, Throwable cause)
+  {
+    super(message, cause);
+  }
+}

--- a/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/IssuerExtractor.java
+++ b/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/IssuerExtractor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.jwt;
+
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+
+/**
+ * Decode JWT to extract issuer field in the JWT claims
+ */
+public class IssuerExtractor
+{
+  private final JwtConsumer baseConsumer;
+
+  /**
+   * jwt consumer used to decode JWT to extract issuer only
+   */
+  IssuerExtractor()
+  {
+    baseConsumer = new JwtConsumerBuilder()
+        .setSkipAllValidators()
+        .setDisableRequireSignature()
+        .setSkipSignatureVerification()
+        .build();
+  }
+
+  public String getIssuer(String encodedJwt) throws InvalidJwtException, MalformedClaimException
+  {
+    return baseConsumer.processToClaims(encodedJwt).getIssuer();
+  }
+}

--- a/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/JwtJwksAuthenticator.java
+++ b/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/JwtJwksAuthenticator.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.jwt;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.server.security.AuthenticationResult;
+import org.apache.druid.server.security.Authenticator;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+
+import javax.annotation.Nullable;
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@JsonTypeName("jwt_jwks")
+public class JwtJwksAuthenticator implements Authenticator
+{
+  private static final Logger LOG = new Logger(JwtJwksAuthenticator.class);
+
+  private final String name;
+  private final String authorizerName;
+  private final String issuer;
+  private final List<String> audience;
+  private final String jwksUri;
+
+  private final JwtVerifier jwtVerifier;
+  private final IssuerExtractor issuerExtractor;
+
+  @JsonCreator
+  public JwtJwksAuthenticator(
+      @JsonProperty("name") String name,
+      @JsonProperty("issuer") String issuer,
+      @JsonProperty("audience") List<String> audience,
+      @JsonProperty("jwksUri") String jwksUri,
+      @JsonProperty("authorizerName") String authorizerName
+  )
+  {
+    this.name = Preconditions.checkNotNull(name, "null Name");
+    this.issuer = Preconditions.checkNotNull(issuer, "null issuer");
+    this.jwksUri = Preconditions.checkNotNull(jwksUri, "null jwksUri");
+    this.authorizerName = authorizerName;
+    this.audience = audience;
+    this.jwtVerifier = new JwtVerifier(issuer, jwksUri, audience);
+    this.issuerExtractor = new IssuerExtractor();
+  }
+
+  @Override
+  public Filter getFilter()
+  {
+    return new HTTPAuthenticationFilter();
+  }
+
+  @Override
+  public Class<? extends Filter> getFilterClass()
+  {
+    return HTTPAuthenticationFilter.class;
+  }
+
+  @Override
+  public String getAuthChallengeHeader()
+  {
+    return "Bearer";
+  }
+
+  @Override
+  public Map<String, String> getInitParameters()
+  {
+    return null;
+  }
+
+  @Override
+  public String getPath()
+  {
+    return "/*";
+  }
+
+  @Override
+  public EnumSet<DispatcherType> getDispatcherType()
+  {
+    return null;
+  }
+
+
+  @Override
+  @Nullable
+  public AuthenticationResult authenticateJDBCContext(Map<String, Object> context)
+  {
+    String bearerToken = (String) context.get("bearer-token");
+
+    if (bearerToken != null) {
+      try {
+        JwtClaims jwtClaims = jwtVerifier.authenticate(bearerToken);
+        if (jwtClaims != null) {
+          LOG.info("JWT validation succeeded!");
+          return new AuthenticationResult(
+              JwtVerifier.getCallerGroup(jwtClaims),
+              authorizerName,
+              name,
+              null
+          );
+        }
+      }
+      catch (InvalidJwtException e) {
+        LOG.error(e, "Invalid Credentails");
+      }
+      catch (MalformedClaimException e) {
+        LOG.error(e, "Missing JWT Custom Claim: groups");
+      }
+    }
+    return null;
+  }
+
+  public class HTTPAuthenticationFilter implements Filter
+  {
+    @Override
+    public void init(FilterConfig filterConfig)
+    {
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+        throws IOException, ServletException
+    {
+      HttpServletResponse httpResp = (HttpServletResponse) servletResponse;
+      String bearerToken = AuthUtils.getBearerTokenFromHttpReq((HttpServletRequest) servletRequest);
+      if (bearerToken == null) {
+        // Request didn't have HTTP bearer token credentials, move on to the next filter
+        filterChain.doFilter(servletRequest, servletResponse);
+        return;
+      }
+
+      // filter JWT verifier based on issuer
+      // if issuer specified doesn't match to issuer from JWT then move on to the next filter
+      try {
+        String extractedIssuer = issuerExtractor.getIssuer(bearerToken);
+        if (!Objects.equals(extractedIssuer, issuer)) {
+          filterChain.doFilter(servletRequest, servletResponse);
+          return;
+        }
+      }
+      catch (InvalidJwtException | MalformedClaimException e) {
+        LOG.error(e, "Invalid JWT Issuer");
+        httpResp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid JWT Issuer");
+        return;
+      }
+
+      // If any jwt authentication error occurs, we send a 401 response immediately
+      // and do not proceed further down the filter chain.
+      try {
+        JwtClaims jwtClaims = jwtVerifier.authenticate(bearerToken);
+        LOG.info("JWT validation succeeded!");
+        // TODO add useful JWT claims into the context filed of AuthenticationResult
+        AuthenticationResult authenticationResult = new AuthenticationResult(
+            JwtVerifier.getCallerGroup(jwtClaims),
+            authorizerName,
+            name,
+            null
+        );
+        servletRequest.setAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
+        filterChain.doFilter(servletRequest, servletResponse);
+      }
+      catch (InvalidJwtException e) {
+        LOG.error(e, "Invalid Credentails");
+        httpResp.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Bearer authentication failed, Invalid JWT");
+      }
+      catch (MalformedClaimException e) {
+        httpResp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing JWT Custom Claim: groups");
+        LOG.error(e, "Missing Custom Claim: groups");
+      }
+    }
+
+    @Override
+    public void destroy()
+    {
+
+    }
+  }
+
+}

--- a/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/JwtVerifier.java
+++ b/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/JwtVerifier.java
@@ -69,16 +69,21 @@ public class JwtVerifier
   /**
    * Return JWT custom claim: groups
    */
-  public static List<String> getClaimGroups(JwtClaims claims) throws MalformedClaimException
+  public static List<String> getClaimGroups(JwtClaims claims) throws InvalidGroupsClaimException
   {
-    return claims.getStringListClaimValue(CLAIM_GROUPS);
+    try {
+      return claims.getStringListClaimValue(CLAIM_GROUPS);
+    }
+    catch (MalformedClaimException e) {
+      throw new InvalidGroupsClaimException("Missing JWT Custom Claim: groups", e);
+    }
   }
 
   /**
    * Caller/Client's groups claim is configured to uniquely identify caller itself.
    * Ideally every Caller/Client service would have a unique group that would be used for authorization.
    */
-  public static String getCallerGroup(JwtClaims claims) throws MalformedClaimException
+  public static String getCallerGroup(JwtClaims claims) throws InvalidGroupsClaimException
   {
     return String.join(",", getClaimGroups(claims));
   }

--- a/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/JwtVerifier.java
+++ b/extensions-contrib/druid-jwt-extensions/src/main/java/org/apache/druid/security/jwt/JwtVerifier.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.jwt;
+
+import org.jose4j.jwk.HttpsJwks;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.jose4j.keys.resolvers.HttpsJwksVerificationKeyResolver;
+
+import java.util.List;
+
+public class JwtVerifier
+{
+  private static final String CLAIM_GROUPS = "groups";
+
+  private final JwtConsumer jwtConsumer;
+
+  public JwtVerifier(
+      String issuer,
+      String jwksUri,
+      List<String> audience
+
+  )
+  {
+    this.jwtConsumer = createConsumer(issuer, jwksUri, audience);
+  }
+
+  private static JwtConsumer createConsumer(
+      String issuer,
+      String jwksUri,
+      List<String> audience
+  )
+  {
+    JwtConsumerBuilder builder = new JwtConsumerBuilder().setExpectedIssuer(issuer)
+                                                         .setVerificationKeyResolver(
+                                                             new HttpsJwksVerificationKeyResolver(
+                                                                 new HttpsJwks(jwksUri)
+                                                             )
+                                                         )
+                                                         .setRequireExpirationTime()
+                                                         .setRequireSubject();
+    if (audience != null) {
+      builder = builder.setExpectedAudience(audience.toArray(new String[0]));
+    }
+    return builder.build();
+
+  }
+
+  /**
+   * Return JWT custom claim: groups
+   */
+  public static List<String> getClaimGroups(JwtClaims claims) throws MalformedClaimException
+  {
+    return claims.getStringListClaimValue(CLAIM_GROUPS);
+  }
+
+  /**
+   * Caller/Client's groups claim is configured to uniquely identify caller itself.
+   * Ideally every Caller/Client service would have a unique group that would be used for authorization.
+   */
+  public static String getCallerGroup(JwtClaims claims) throws MalformedClaimException
+  {
+    return String.join(",", getClaimGroups(claims));
+  }
+
+  public JwtClaims authenticate(String encodedJwt) throws InvalidJwtException
+  {
+    return jwtConsumer.processToClaims(encodedJwt);
+  }
+
+}

--- a/extensions-contrib/druid-jwt-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/druid-jwt-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.security.jwt.DruidJwtModule

--- a/extensions-contrib/druid-jwt-extensions/src/test/java/org/apache/druid/security/jwt/AuthUtilsTest.java
+++ b/extensions-contrib/druid-jwt-extensions/src/test/java/org/apache/druid/security/jwt/AuthUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.jwt;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class AuthUtilsTest
+{
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+
+  @Test
+  public void testGetBearerTokenFromHttpReq()
+  {
+    String bearerToken = "TestToken1234";
+    HttpServletRequest httpReq = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(httpReq.getHeader(AUTHORIZATION_HEADER))
+           .thenReturn("Bearer " + bearerToken, bearerToken);
+    String bearerResult = AuthUtils.getBearerTokenFromHttpReq(httpReq);
+    assertEquals(bearerResult, bearerToken);
+    String nullResult = AuthUtils.getBearerTokenFromHttpReq(httpReq);
+    assertNull(nullResult);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
         <module>extensions-contrib/opentelemetry-emitter</module>
         <module>extensions-contrib/opencensus-extensions</module>
         <module>extensions-contrib/confluent-extensions</module>
+        <module>extensions-contrib/druid-jwt-extensions</module>
         <module>extensions-contrib/opentelemetry-extensions</module>
         <!-- distribution packaging -->
         <module>distribution</module>


### PR DESCRIPTION
### Description
an extension for verifying [JSON Web Token](http://tools.ietf.org/html/rfc7519) (JWT) that has been transferred between two parties. The extension retrieves and parses JSON Web Keys (JWK) from an HTTPS JWKS endpoint.


##### runtime config setup
Use the following syntax to configure a named authenticator:
```
druid.auth.authenticator.<authenticatorName>.<authenticatorProperty>
```
For multiple Id servers:
```
druid.auth.authenticatorChain=["jwt", "okta"]
```
example 

```
druid.extensions.loadList=["druid-jwt-extensions"]
druid.auth.authenticatorChain=["jwt", "okta"]
## JWT ##
druid.auth.authenticator.jwt.type=jwt_jwks
druid.auth.authenticator.jwt.audience=["AABBBAABBB"] // optional
druid.auth.authenticator.jwt.issuer=https://{YOU_DOMAIN}/v1/defualt
druid.auth.authenticator.jwt.jwksUri=https://{YOU_DOMAIN}/v1/defualt/.well-known/keys
druid.auth.authenticator.vault.jwtGroupIdentityMap={"jwtgroup":"basicauthzgroup"}
druid.auth.authenticator.jwt.authorizerName=basic

```

`druid.auth.authenticator.jwt.jwtGroupIdentityMap` is optional. This property maps JWT custom groups claim to the identity used in authorization. For a set of users within same group, this property would map those JWTs to same identity in the authorizer. If the property is not set, the JWT `sub` claim is used as the identity in the authorizer.

<hr>

Retrieve JWT and Invoke the API with the Authorization: Bearer $JWT_AUTH_TOKEN header.

```
curl -H "Authorization: Bearer $JWT_AUTH_TOKEN" -X 'POST' -H 'Content-Type:application/json' -d @quickstart/tutorial/wikipedia-top-pages-sql.json http://localhost:8888/druid/v2/sql
```



<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
