### PR TITLE
Migrate to distroless/java11-debian11 as base OS

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG JDK_VERSION=8
+ARG JDK_VERSION=11
 FROM alpine as extractor
 
 ARG VERSION=
@@ -30,7 +30,7 @@ RUN tar -zxf /src/apache-druid-${VERSION}-bin.tar.gz -C /opt \
 
 FROM amd64/busybox:1.30.0-glibc as busybox
 
-FROM gcr.io/distroless/java:$JDK_VERSION
+FROM gcr.io/distroless/java$JDK_VERSION-debian11
 LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 
 COPY --from=busybox /bin/busybox /busybox/busybox


### PR DESCRIPTION
See upstream Dockerfile: https://github.com/apache/druid/blob/master/distribution/docker/Dockerfile#LL53-L54C49

See also (internal): https://github.com/confluentinc/cc-druid/pull/1154