### PR TITLE
Move to Java 17

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,7 +28,7 @@ blocks:
       prologue:
         commands:
           - echo $SEMAPHORE_WORKFLOW_ID
-          - sem-version java 11
+          - sem-version java 17
           - checkout
       jobs:
         - name: "Install"
@@ -45,7 +45,7 @@ blocks:
       prologue:
         commands:
           - echo $SEMAPHORE_WORKFLOW_ID
-          - sem-version java 11
+          - sem-version java 17
           - checkout
           - cache restore
       jobs:

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG JDK_VERSION=11
+ARG JDK_VERSION=17
 FROM alpine as extractor
 
 ARG VERSION=

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG JDK_VERSION=17
+ARG JDK_VERSION=11
 FROM alpine as extractor
 
 ARG VERSION=

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -43,7 +43,7 @@
     <properties>
         <!-- the default value is a repeated flag from the command line, since blank value is not allowed -->
         <druid.distribution.pulldeps.opts>--clean</druid.distribution.pulldeps.opts>
-        <docker.jdk.version>11</docker.jdk.version>
+        <docker.jdk.version>17</docker.jdk.version>
     </properties>
 
     <build>


### PR DESCRIPTION
### Description

2 changes:
1. Make the JVM version for tests run as part of semaphore use Java 17
2. Make the default for building and running Java 17


