### PR TITLE
Use apache-jar-resource-bundle:1.5 instead of 1.5-SNAPSHOT (#14054)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1503,7 +1503,7 @@
                                 <projectName>Apache Druid</projectName>
                             </properties>
                             <resourceBundles>
-                                <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT</resourceBundle>
+                                <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5</resourceBundle>
                             </resourceBundles>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Cherry-pick of https://github.com/apache/druid/commit/cb302e1bd1092048875919d640bb65916c4ac796 from https://github.com/apache/druid/pull/14054 in order to fix the broken build. 
