### PR TITLE
OBSDATA-1354: Druid 25 with confluent patches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# See go/codeowners - automatically generated for confluentinc/druid:
-*	@confluentinc/observability
+*	@confluentinc/obs-data

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# See go/codeowners - automatically generated for confluentinc/druid:
+*	@confluentinc/observability

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@confluentinc/obs-data
+*	@confluentinc/obs-data @confluentinc/obs-oncall

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,3 +1,8 @@
+# This file is managed by ServiceBot plugin - Semaphore. The content in this file is created using a common
+# template and configurations in service.yml.
+# Modifications in this file will be overwritten by generated content in the nightly run.
+# For more information, please refer to the page:
+# https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2871296194/Add+SemaphoreCI
 apiVersion: v1alpha
 kind: Project
 metadata:

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -1,0 +1,33 @@
+apiVersion: v1alpha
+kind: Project
+metadata:
+  name: druid
+  description: ""
+spec:
+  visibility: private
+  repository:
+    url: git@github.com:confluentinc/druid.git
+    run_on:
+    - branches
+    - tags
+    - pull_requests
+    pipeline_file: .semaphore/semaphore.yml
+    integration_type: github_app
+    status:
+      pipeline_files:
+      - path: .semaphore/semaphore.yml
+        level: pipeline
+  custom_permissions: true
+  debug_permissions:
+  - empty
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag
+  attach_permissions:
+  - default_branch
+  - non_default_branch
+  - pull_request
+  - forked_pull_request
+  - tag

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -17,6 +17,10 @@ spec:
       pipeline_files:
       - path: .semaphore/semaphore.yml
         level: pipeline
+    whitelist:
+      branches:
+      - master
+      - /^.*-confluent$/
   custom_permissions: true
   debug_permissions:
   - empty

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,7 +28,7 @@ blocks:
       prologue:
         commands:
           - echo $SEMAPHORE_WORKFLOW_ID
-          - sem-version java 11
+          - sem-version java 17
           - checkout
       jobs:
         - name: "Install"
@@ -45,7 +45,7 @@ blocks:
       prologue:
         commands:
           - echo $SEMAPHORE_WORKFLOW_ID
-          - sem-version java 11
+          - sem-version java 17
           - checkout
           - cache restore
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,7 +63,7 @@ blocks:
 
         - name: "forbidden api checks"
           commands:
-            - ${MVN} compile ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+            - ${MVN} test-compile ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
             - ${MVN} forbiddenapis:check forbiddenapis:testCheck --fail-at-end
 
         - name: "pmd checks"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -74,6 +74,24 @@ blocks:
           commands:
             - ${MVN} spotbugs:check --fail-at-end -pl '!benchmarks'
 
+        - name: "analyze dependencies"
+          commands:
+            - >
+              ${MVN} ${MAVEN_SKIP} dependency:analyze -DoutputXML=true -DignoreNonCompile=true -DfailOnWarning=true --fail-at-end || { echo "
+
+              The dependency analysis has found a dependency that is either:
+              1) Used and undeclared: These are available as a transitive dependency but should be explicitly
+              added to the POM to ensure the dependency version. The XML to add the dependencies to the POM is
+              shown above.
+              2) Unused and declared: These are not needed and removing them from the POM will speed up the build
+              and reduce the artifact size. The dependencies to remove are shown above.
+              If there are false positive dependency analysis warnings, they can be suppressed:
+              https://maven.apache.org/plugins/maven-dependency-plugin/analyze-mojo.html#usedDependencies
+              https://maven.apache.org/plugins/maven-dependency-plugin/examples/exclude-dependencies-from-dependency-analysis.html
+              For more information, refer to:
+              https://maven.apache.org/plugins/maven-dependency-plugin/analyze-mojo.html
+              " && false; }
+
         - name: "Confluent Extensions"
           env_vars:
             - name: MAVEN_PROJECTS

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -129,5 +129,5 @@ blocks:
         - name: "Other Tests"
           env_vars:
             - name: MAVEN_PROJECTS
-              value: '!server,!processing,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-contrib/confluent-extensions'
+              value: '!server,!processing,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-contrib/confluent-extensions,!integration-tests-ex/cases'
           commands: *run_tests

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -78,7 +78,7 @@ blocks:
               value: extensions-contrib/confluent-extensions
           commands: &run_tests
             - >
-              MAVEN_OPTS="${MAVEN_OPTS} -Xmx800m" ${MVN} test -pl ${MAVEN_PROJECTS}
+              MAVEN_OPTS="${MAVEN_OPTS} -Xmx1g" ${MVN} test -pl ${MAVEN_PROJECTS}
               ${MAVEN_SKIP} -Dremoteresources.skip=true
 
         - name: "Server"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,8 +2,7 @@ version: v1.0
 name: Apache Druid
 agent:
   machine:
-    type: e1-standard-4
-    os_image: ubuntu1804
+    type: s1-prod-ubuntu20-04-amd64-1
 
 blocks:
   - name: "Install"
@@ -28,6 +27,7 @@ blocks:
           value: "-DskipTests -Djacoco.skip=true"
       prologue:
         commands:
+          - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 11
           - checkout
       jobs:
@@ -44,6 +44,7 @@ blocks:
       env_vars: *env_vars
       prologue:
         commands:
+          - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 11
           - checkout
           - cache restore

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,7 +28,7 @@ blocks:
           value: "-DskipTests -Djacoco.skip=true"
       prologue:
         commands:
-          - sem-version java 8
+          - sem-version java 11
           - checkout
       jobs:
         - name: "Install"
@@ -44,7 +44,7 @@ blocks:
       env_vars: *env_vars
       prologue:
         commands:
-          - sem-version java 8
+          - sem-version java 11
           - checkout
           - cache restore
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -50,6 +50,7 @@ blocks:
       jobs:
         - name: "animal sniffer checks"
           commands:
+            - ${MVN} test-compile ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
             - ${MVN} animal-sniffer:check --fail-at-end
 
         - name: "checkstyle"
@@ -62,6 +63,7 @@ blocks:
 
         - name: "forbidden api checks"
           commands:
+            - ${MVN} compile ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
             - ${MVN} forbiddenapis:check forbiddenapis:testCheck --fail-at-end
 
         - name: "pmd checks"

--- a/core/src/main/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEvent.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEvent.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.emitter.service;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.core.EventMap;
+import org.joda.time.DateTime;
+
+public class SegmentMetadataEvent implements Event
+{
+  public static final String FEED = "feed";
+  public static final String DATASOURCE = "dataSource";
+  public static final String CREATED_TIME = "createdTime";
+  public static final String START_TIME = "startTime";
+  public static final String END_TIME = "endTime";
+  public static final String VERSION = "version";
+  public static final String IS_COMPACTED = "isCompacted";
+
+  private final DateTime createdTime;
+  private final String dataSource;
+  private final DateTime startTime;
+  private final DateTime endTime;
+  private final String version;
+  private final boolean isCompacted;
+
+  public SegmentMetadataEvent(
+      String dataSource,
+      DateTime createdTime,
+      DateTime startTime,
+      DateTime endTime,
+      String version,
+      boolean isCompacted
+  )
+  {
+    this.dataSource = dataSource;
+    this.createdTime = createdTime;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.version = version;
+    this.isCompacted = isCompacted;
+  }
+
+  @Override
+  public String getFeed()
+  {
+    return "segment_metadata";
+  }
+
+  public DateTime getCreatedTime()
+  {
+    return createdTime;
+  }
+
+  public DateTime getStartTime()
+  {
+    return startTime;
+  }
+
+  public DateTime getEndTime()
+  {
+    return endTime;
+  }
+
+  public String getDataSource()
+  {
+    return dataSource;
+  }
+
+  public String getVersion()
+  {
+    return version;
+  }
+
+  public boolean isCompacted()
+  {
+    return isCompacted;
+  }
+
+  @Override
+  @JsonValue
+  public EventMap toMap()
+  {
+
+    return EventMap.builder()
+        .put(FEED, getFeed())
+        .put(DATASOURCE, dataSource)
+        .put(CREATED_TIME, createdTime)
+        .put(START_TIME, startTime)
+        .put(END_TIME, endTime)
+        .put(VERSION, version)
+        .put(IS_COMPACTED, isCompacted)
+        .build();
+  }
+}

--- a/core/src/test/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEventTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEventTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.emitter.service;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.DateTimes;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SegmentMetadataEventTest
+{
+  @Test
+  public void testBasicEvent()
+  {
+    SegmentMetadataEvent event = new SegmentMetadataEvent(
+        "dummy_datasource",
+        DateTimes.of("2001-01-01T00:00:00.000Z"),
+        DateTimes.of("2001-01-02T00:00:00.000Z"),
+        DateTimes.of("2001-01-03T00:00:00.000Z"),
+        "dummy_version",
+        true
+    );
+
+    Assert.assertEquals(
+        ImmutableMap.<String, Object>builder()
+            .put(SegmentMetadataEvent.FEED, "segment_metadata")
+            .put(SegmentMetadataEvent.DATASOURCE, "dummy_datasource")
+            .put(SegmentMetadataEvent.CREATED_TIME, DateTimes.of("2001-01-01T00:00:00.000Z"))
+            .put(SegmentMetadataEvent.START_TIME, DateTimes.of("2001-01-02T00:00:00.000Z"))
+            .put(SegmentMetadataEvent.END_TIME, DateTimes.of("2001-01-03T00:00:00.000Z"))
+            .put(SegmentMetadataEvent.VERSION, "dummy_version")
+            .put(SegmentMetadataEvent.IS_COMPACTED, true)
+            .build(),
+        event.toMap()
+    );
+  }
+}

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -55,15 +55,12 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     && wget ${BASH_URL} -O /bin/bash \
     && chmod 755 /bin/bash
 
-COPY --from=extractor /opt /opt
-COPY ./docker/druid.sh /druid.sh
-
 RUN addgroup -S -g 1000 druid \
  && adduser -S -u 1000 -D -H -h /opt/druid -s /bin/sh -g '' -G druid druid
 
-COPY --chown=druid:druid --from=builder /opt /opt
-COPY distribution/docker/druid.sh /druid.sh
-COPY distribution/docker/peon.sh /peon.sh
+COPY --chown=druid:druid --from=extractor /opt /opt
+COPY ./docker/druid.sh /druid.sh
+COPY ./docker/peon.sh /peon.sh
 
 # create necessary directories which could be mounted as volume
 #   /opt/druid/var is used to keep individual files(e.g. log) of each Druid service

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -163,6 +163,32 @@ if [ -n "$DRUID_MAXNEWSIZE" ]; then setJavaKey ${SERVICE} -XX:MaxNewSize -XX:Max
 if [ -n "$DRUID_NEWSIZE" ]; then setJavaKey ${SERVICE} -XX:NewSize -XX:NewSize=${DRUID_NEWSIZE}; fi
 if [ -n "$DRUID_MAXDIRECTMEMORYSIZE" ]; then setJavaKey ${SERVICE} -XX:MaxDirectMemorySize -XX:MaxDirectMemorySize=${DRUID_MAXDIRECTMEMORYSIZE}; fi
 
+# If java version is 17 or greater, add command line args to enable class loading via Guice
+JAVA_MAJOR="$(java -version 2>&1 | sed -n -E 's/.* version "([^."]*).*/\1/p')"
+
+if [ "$JAVA_MAJOR" != "" ] && [ "$JAVA_MAJOR" -ge "17" ]
+then
+  # Must disable strong encapsulation for certain packages on Java 17.
+  JAVA_OPTS="--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
+    --add-exports=java.base/jdk.internal.perf=ALL-UNNAMED \
+    --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED \
+    --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+    --add-opens=java.base/java.io=ALL-UNNAMED \
+    --add-opens=java.base/java.lang=ALL-UNNAMED \
+    --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
+    $JAVA_OPTS"
+elif [ "$JAVA_MAJOR" != "" ] && [ "$JAVA_MAJOR" -ge "11" ]
+then
+  # Parameters below are required to use datasketches-memory as a library
+  JAVA_OPTS="$JAVA_OPTS \
+    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
+    --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+fi
+
 # Combine options from jvm.config and those given as JAVA_OPTS
 # If a value is specified in both then JAVA_OPTS will take precedence when using OpenJDK
 # However this behavior is not part of the spec and is thus implementation specific

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -789,30 +789,6 @@
                       <dockerfile>docker/Dockerfile</dockerfile>
                     </configuration>
                   </execution>
-                  <execution>
-                    <id>tag-latest-jdk11</id>
-                    <goals>
-                      <goal>build</goal>
-                      <goal>tag</goal>
-                    </goals>
-                    <configuration>
-                      <repository>docker.io/apache/druid</repository>
-                      <tag>latest-jdk11</tag>
-                      <dockerfile>docker/Dockerfile.java11</dockerfile>
-                    </configuration>
-                  </execution>
-                  <execution>
-                    <id>tag-version-jdk11</id>
-                    <goals>
-                      <goal>build</goal>
-                      <goal>tag</goal>
-                    </goals>
-                    <configuration>
-                      <repository>docker.io/apache/druid</repository>
-                      <tag>${project.version}-jdk11</tag>
-                      <dockerfile>docker/Dockerfile.java11</dockerfile>
-                    </configuration>
-                  </execution>
                 </executions>
                 <configuration>
                   <buildArgs>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -50,6 +50,7 @@
     <properties>
         <!-- the default value is a repeated flag from the command line, since blank value is not allowed -->
         <druid.distribution.pulldeps.opts>--clean</druid.distribution.pulldeps.opts>
+        <docker.jdk.version>11</docker.jdk.version>
     </properties>
 
     <build>
@@ -793,6 +794,7 @@
                 <configuration>
                   <buildArgs>
                     <VERSION>${project.version}</VERSION>
+                    <JDK_VERSION>${docker.jdk.version}</JDK_VERSION>
                   </buildArgs>
                 </configuration>
               </plugin>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -50,7 +50,6 @@
     <properties>
         <!-- the default value is a repeated flag from the command line, since blank value is not allowed -->
         <druid.distribution.pulldeps.opts>--clean</druid.distribution.pulldeps.opts>
-        <skipDockerMysql>true</skipDockerMysql>
     </properties>
 
     <build>
@@ -771,7 +770,7 @@
                       <goal>tag</goal>
                     </goals>
                     <configuration>
-                      <repository>docker.io/apache/incubator-druid</repository>
+                      <repository>docker.io/apache/druid</repository>
                       <tag>latest</tag>
                       <dockerfile>docker/Dockerfile</dockerfile>
                     </configuration>
@@ -783,35 +782,33 @@
                       <goal>tag</goal>
                     </goals>
                     <configuration>
-                      <repository>docker.io/apache/incubator-druid</repository>
+                      <repository>docker.io/apache/druid</repository>
                       <tag>${project.version}</tag>
                       <dockerfile>docker/Dockerfile</dockerfile>
                     </configuration>
                   </execution>
                   <execution>
-                    <id>tag-latest-mysql</id>
+                    <id>tag-latest-jdk11</id>
                     <goals>
                       <goal>build</goal>
                       <goal>tag</goal>
                     </goals>
                     <configuration>
-                      <repository>docker.io/apache/incubator-druid-mysql</repository>
-                      <tag>latest</tag>
-                      <dockerfile>docker/Dockerfile.mysql</dockerfile>
-                      <skip>${skipDockerMysql}</skip>
+                      <repository>docker.io/apache/druid</repository>
+                      <tag>latest-jdk11</tag>
+                      <dockerfile>docker/Dockerfile.java11</dockerfile>
                     </configuration>
                   </execution>
                   <execution>
-                    <id>tag-version-mysql</id>
+                    <id>tag-version-jdk11</id>
                     <goals>
                       <goal>build</goal>
                       <goal>tag</goal>
                     </goals>
                     <configuration>
-                      <repository>docker.io/apache/incubator-druid-mysql</repository>
-                      <tag>${project.version}</tag>
-                      <dockerfile>docker/Dockerfile.mysql</dockerfile>
-                      <skip>${skipDockerMysql}</skip>
+                      <repository>docker.io/apache/druid</repository>
+                      <tag>${project.version}-jdk11</tag>
+                      <dockerfile>docker/Dockerfile.java11</dockerfile>
                     </configuration>
                   </execution>
                 </executions>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -637,6 +637,8 @@
                                         <argument>org.apache.druid.extensions.contrib:druid-opencensus-extensions</argument>
                                         <argument>-c</argument>
                                         <argument>io.confluent.druid.extensions:confluent-extensions</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:opentelemetry-emitter</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -50,7 +50,7 @@
     <properties>
         <!-- the default value is a repeated flag from the command line, since blank value is not allowed -->
         <druid.distribution.pulldeps.opts>--clean</druid.distribution.pulldeps.opts>
-        <docker.jdk.version>11</docker.jdk.version>
+        <docker.jdk.version>17</docker.jdk.version>
     </properties>
 
     <build>

--- a/docs/development/extensions-contrib/kafka-emitter.md
+++ b/docs/development/extensions-contrib/kafka-emitter.md
@@ -36,20 +36,28 @@ to monitor the status of your Druid cluster with this extension.
 
 All the configuration parameters for the Kafka emitter are under `druid.emitter.kafka`.
 
-|property|description|required?|default|
-|--------|-----------|---------|-------|
-|`druid.emitter.kafka.bootstrap.servers`|Comma-separated Kafka broker. (`[hostname:port],[hostname:port]...`)|yes|none|
-|`druid.emitter.kafka.metric.topic`|Kafka topic name for emitter's target to emit service metric.|yes|none|
-|`druid.emitter.kafka.alert.topic`|Kafka topic name for emitter's target to emit alert.|yes|none|
-|`druid.emitter.kafka.request.topic`|Kafka topic name for emitter's target to emit request logs. If left empty then request logs will not be sent to the Kafka topic.|no|none|
-|`druid.emitter.kafka.producer.config`|JSON formatted configuration which user want to set additional properties to Kafka producer.|no|none|
-|`druid.emitter.kafka.clusterName`|Optional value to specify name of your druid cluster. It can help make groups in your monitoring environment. |no|none|
+| property                                           | description                                                                                                                                                                             | required? | default               |
+|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|-----------------------|
+| `druid.emitter.kafka.bootstrap.servers`            | Comma-separated Kafka broker. (`[hostname:port],[hostname:port]...`)                                                                                                                    | yes       | none                  |
+| `druid.emitter.kafka.event.types`                  | Comma-separated event types. <br/>Choices: alerts, metrics, requests, segmentMetadata                                                                                                   | no        | ["metrics", "alerts"] |
+| `druid.emitter.kafka.metric.topic`                 | Kafka topic name for emitter's target to emit service metric. If `event.types` contains `metrics`, this field cannot be left empty                                                      | no        | none                  |
+| `druid.emitter.kafka.alert.topic`                  | Kafka topic name for emitter's target to emit alert. If `event.types` contains `alerts`, this field cannot be left empty                                                                | no        | none                  |
+| `druid.emitter.kafka.request.topic`                | Kafka topic name for emitter's target to emit request logs. If `event.types` contains `requests`, this field cannot be left empty                                                       | no        | none                  |
+| `druid.emitter.kafka.segmentMetadata.topic`        | Kafka topic name for emitter's target to emit segments related metadata. If `event.types` contains `segmentMetadata`, this field cannot be left empty                                   | no        | none                  |
+| `druid.emitter.kafka.segmentMetadata.topic.format` | Format in which segment related metadata will be emitted. <br/>Choices: json, protobuf.<br/> If set to `protobuf`, then segment metadata is emitted in `DruidSegmentEvent.proto` format | no        | json                  |
+| `druid.emitter.kafka.producer.config`              | JSON formatted configuration which user want to set additional properties to Kafka producer.                                                                                            | no        | none                  |
+| `druid.emitter.kafka.clusterName`                  | Optional value to specify name of your druid cluster. It can help make groups in your monitoring environment.                                                                           | no        | none                  |
 
 ### Example
 
 ```
 druid.emitter.kafka.bootstrap.servers=hostname1:9092,hostname2:9092
-druid.emitter.kafka.metric.topic=druid-metric
+druid.emitter.kafka.event.types=["alerts", "requests", "segmentMetadata"]
 druid.emitter.kafka.alert.topic=druid-alert
+druid.emitter.kafka.request.topic=druid-request-logs
+druid.emitter.kafka.segmentMetadata.topic=druid-segment-metadata
+druid.emitter.kafka.segmentMetadata.topic.format=protobuf 
 druid.emitter.kafka.producer.config={"max.block.ms":10000}
 ```
+Whenever `druid.emitter.kafka.segmentMetadata.topic.format` field is updated, it is recommended to also update  `druid.emitter.kafka.segmentMetadata.topic` to avoid the same topic from getting polluted with different formats of segment metadata.
+

--- a/extensions-contrib/confluent-extensions/pom.xml
+++ b/extensions-contrib/confluent-extensions/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>24.0.2</version>
+    <version>25.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/confluent-extensions/pom.xml
+++ b/extensions-contrib/confluent-extensions/pom.xml
@@ -34,6 +34,31 @@
       <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>

--- a/extensions-contrib/confluent-extensions/pom.xml
+++ b/extensions-contrib/confluent-extensions/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.17.0</version>
+    <version>0.19.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/confluent-extensions/pom.xml
+++ b/extensions-contrib/confluent-extensions/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>24.0.1</version>
+    <version>24.0.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/confluent-extensions/pom.xml
+++ b/extensions-contrib/confluent-extensions/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.19.0</version>
+    <version>0.21.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/confluent-extensions/pom.xml
+++ b/extensions-contrib/confluent-extensions/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.22.1</version>
+    <version>24.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/confluent-extensions/pom.xml
+++ b/extensions-contrib/confluent-extensions/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>24.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/confluent-extensions/pom.xml
+++ b/extensions-contrib/confluent-extensions/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.21.0</version>
+    <version>0.22.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/confluent-extensions/pom.xml
+++ b/extensions-contrib/confluent-extensions/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>24.0.0</version>
+    <version>24.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/confluent-extensions/src/main/java/io/confluent/druid/transform/ExtractTenantTopicTransform.java
+++ b/extensions-contrib/confluent-extensions/src/main/java/io/confluent/druid/transform/ExtractTenantTopicTransform.java
@@ -9,7 +9,9 @@ import com.google.common.base.Preconditions;
 import org.apache.druid.segment.transform.RowFunction;
 import org.apache.druid.segment.transform.Transform;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 public class ExtractTenantTopicTransform implements Transform
 {
@@ -51,6 +53,15 @@ public class ExtractTenantTopicTransform implements Transform
       Object value = row.getRaw(fieldName);
       return value == null ? null : TenantUtils.extractTenantTopic(value.toString());
     };
+  }
+
+  @Override
+  public Set<String> getRequiredColumns()
+  {
+    Set<String> columns = new HashSet<String>();
+    columns.add(this.name);
+    columns.add(this.fieldName);
+    return columns;
   }
 
   @Override

--- a/extensions-contrib/confluent-extensions/src/main/java/io/confluent/druid/transform/ExtractTenantTransform.java
+++ b/extensions-contrib/confluent-extensions/src/main/java/io/confluent/druid/transform/ExtractTenantTransform.java
@@ -9,7 +9,9 @@ import com.google.common.base.Preconditions;
 import org.apache.druid.segment.transform.RowFunction;
 import org.apache.druid.segment.transform.Transform;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 public class ExtractTenantTransform implements Transform
 {
@@ -51,6 +53,15 @@ public class ExtractTenantTransform implements Transform
       Object value = row.getRaw(fieldName);
       return value == null ? null : TenantUtils.extractTenant(value.toString());
     };
+  }
+
+  @Override
+  public Set<String> getRequiredColumns()
+  {
+    Set<String> columns = new HashSet<String>();
+    columns.add(this.name);
+    columns.add(this.fieldName);
+    return columns;
   }
 
   @Override

--- a/extensions-contrib/confluent-extensions/src/test/java/io/confluent/druid/transform/ExtractTransformTest.java
+++ b/extensions-contrib/confluent-extensions/src/test/java/io/confluent/druid/transform/ExtractTransformTest.java
@@ -28,11 +28,7 @@ public class ExtractTransformTest
   private static final MapInputRowParser PARSER = new MapInputRowParser(
       new TimeAndDimsParseSpec(
           new TimestampSpec("t", "auto", DateTimes.of("2020-01-01")),
-          new DimensionsSpec(
-              DimensionsSpec.getDefaultSchemas(ImmutableList.of("topic", "tenant")),
-              null,
-              null
-          )
+          new DimensionsSpec( DimensionsSpec.getDefaultSchemas(ImmutableList.of("topic", "tenant")))
       )
   );
 

--- a/extensions-contrib/confluent-extensions/src/test/java/io/confluent/druid/transform/ExtractTransformTest.java
+++ b/extensions-contrib/confluent-extensions/src/test/java/io/confluent/druid/transform/ExtractTransformTest.java
@@ -28,7 +28,7 @@ public class ExtractTransformTest
   private static final MapInputRowParser PARSER = new MapInputRowParser(
       new TimeAndDimsParseSpec(
           new TimestampSpec("t", "auto", DateTimes.of("2020-01-01")),
-          new DimensionsSpec( DimensionsSpec.getDefaultSchemas(ImmutableList.of("topic", "tenant")))
+          new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("topic", "tenant")))
       )
   );
 

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -86,7 +86,11 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -117,5 +121,45 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+    </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.7.0</version>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>detect</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -19,17 +19,20 @@
 
 package org.apache.druid.emitter.kafka;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import org.apache.druid.emitter.kafka.KafkaEmitterConfig.EventType;
 import org.apache.druid.emitter.kafka.MemoryBoundLinkedBlockingQueue.ObjectContainer;
-import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.emitter.proto.DruidSegmentEvent;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.core.Emitter;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.core.EventMap;
 import org.apache.druid.java.util.emitter.service.AlertEvent;
+import org.apache.druid.java.util.emitter.service.SegmentMetadataEvent;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.server.log.RequestLogEvent;
 import org.apache.kafka.clients.producer.Callback;
@@ -37,9 +40,11 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -55,14 +60,16 @@ public class KafkaEmitter implements Emitter
   private final AtomicLong metricLost;
   private final AtomicLong alertLost;
   private final AtomicLong requestLost;
+  private final AtomicLong segmentMetadataLost;
   private final AtomicLong invalidLost;
 
   private final KafkaEmitterConfig config;
-  private final Producer<String, String> producer;
+  private final Producer<String, byte[]> producer;
   private final ObjectMapper jsonMapper;
-  private final MemoryBoundLinkedBlockingQueue<String> metricQueue;
-  private final MemoryBoundLinkedBlockingQueue<String> alertQueue;
-  private final MemoryBoundLinkedBlockingQueue<String> requestQueue;
+  private final MemoryBoundLinkedBlockingQueue<byte[]> metricQueue;
+  private final MemoryBoundLinkedBlockingQueue<byte[]> alertQueue;
+  private final MemoryBoundLinkedBlockingQueue<byte[]> requestQueue;
+  private final MemoryBoundLinkedBlockingQueue<byte[]> segmentMetadataQueue;
   private final ScheduledExecutorService scheduler;
 
   protected int sendInterval = DEFAULT_SEND_INTERVAL_SECONDS;
@@ -78,10 +85,12 @@ public class KafkaEmitter implements Emitter
     this.metricQueue = new MemoryBoundLinkedBlockingQueue<>(queueMemoryBound);
     this.alertQueue = new MemoryBoundLinkedBlockingQueue<>(queueMemoryBound);
     this.requestQueue = new MemoryBoundLinkedBlockingQueue<>(queueMemoryBound);
+    this.segmentMetadataQueue = new MemoryBoundLinkedBlockingQueue<>(queueMemoryBound);
     this.scheduler = Executors.newScheduledThreadPool(4);
     this.metricLost = new AtomicLong(0L);
     this.alertLost = new AtomicLong(0L);
     this.requestLost = new AtomicLong(0L);
+    this.segmentMetadataLost = new AtomicLong(0L);
     this.invalidLost = new AtomicLong(0L);
   }
 
@@ -96,7 +105,7 @@ public class KafkaEmitter implements Emitter
   }
 
   @VisibleForTesting
-  protected Producer<String, String> setKafkaProducer()
+  protected Producer<String, byte[]> setKafkaProducer()
   {
     ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
     try {
@@ -105,7 +114,7 @@ public class KafkaEmitter implements Emitter
       Properties props = new Properties();
       props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getBootstrapServers());
       props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-      props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
       props.put(ProducerConfig.RETRIES_CONFIG, DEFAULT_RETRIES);
       props.putAll(config.getKafkaProducerConfig());
 
@@ -119,18 +128,26 @@ public class KafkaEmitter implements Emitter
   @Override
   public void start()
   {
-    scheduler.schedule(this::sendMetricToKafka, sendInterval, TimeUnit.SECONDS);
-    scheduler.schedule(this::sendAlertToKafka, sendInterval, TimeUnit.SECONDS);
-    if (config.getRequestTopic() != null) {
+    Set<EventType> eventTypes = config.getEventTypes();
+    if (eventTypes.contains(EventType.METRICS)) {
+      scheduler.schedule(this::sendMetricToKafka, sendInterval, TimeUnit.SECONDS);
+    }
+    if (eventTypes.contains(EventType.ALERTS)) {
+      scheduler.schedule(this::sendAlertToKafka, sendInterval, TimeUnit.SECONDS);
+    }
+    if (eventTypes.contains(EventType.REQUESTS)) {
       scheduler.schedule(this::sendRequestToKafka, sendInterval, TimeUnit.SECONDS);
     }
+    if (eventTypes.contains(EventType.SEGMENTMETADATA)) {
+      scheduler.schedule(this::sendSegmentMetadataToKafka, sendInterval, TimeUnit.SECONDS);
+    }
     scheduler.scheduleWithFixedDelay(() -> {
-      log.info(
-          "Message lost counter: metricLost=[%d], alertLost=[%d], requestLost=[%d], invalidLost=[%d]",
+      log.info("Message lost counter: metricLost=[%d], alertLost=[%d], requestLost=[%d], invalidLost=[%d] segmentMetadataLost=[%d]",
           metricLost.get(),
           alertLost.get(),
           requestLost.get(),
-          invalidLost.get()
+          invalidLost.get(),
+          segmentMetadataLost.get()
       );
     }, DEFAULT_SEND_LOST_INTERVAL_MINUTES, DEFAULT_SEND_LOST_INTERVAL_MINUTES, TimeUnit.MINUTES);
     log.info("Starting Kafka Emitter.");
@@ -151,9 +168,14 @@ public class KafkaEmitter implements Emitter
     sendToKafka(config.getRequestTopic(), requestQueue, setProducerCallback(requestLost));
   }
 
-  private void sendToKafka(final String topic, MemoryBoundLinkedBlockingQueue<String> recordQueue, Callback callback)
+  private void sendSegmentMetadataToKafka()
   {
-    ObjectContainer<String> objectToSend;
+    sendToKafka(config.getSegmentMetadataTopic(), segmentMetadataQueue, setProducerCallback(segmentMetadataLost));
+  }
+
+  private void sendToKafka(final String topic, MemoryBoundLinkedBlockingQueue<byte[]> recordQueue, Callback callback)
+  {
+    ObjectContainer<byte[]> objectToSend;
     try {
       while (true) {
         objectToSend = recordQueue.take();
@@ -173,35 +195,84 @@ public class KafkaEmitter implements Emitter
         EventMap map = event.toMap();
         if (config.getClusterName() != null) {
           map = map.asBuilder()
-                   .put("clusterName", config.getClusterName())
-                   .build();
+              .put("clusterName", config.getClusterName())
+              .build();
         }
 
-        String resultJson = jsonMapper.writeValueAsString(map);
-
-        ObjectContainer<String> objectContainer = new ObjectContainer<>(
-            resultJson,
-            StringUtils.toUtf8(resultJson).length
+        byte[] resultBytes = jsonMapper.writeValueAsBytes(map);
+        ObjectContainer<byte[]> objectContainer = new ObjectContainer<>(
+            resultBytes,
+            resultBytes.length
         );
+        Set<EventType> eventTypes = config.getEventTypes();
         if (event instanceof ServiceMetricEvent) {
-          if (!metricQueue.offer(objectContainer)) {
+          if (!eventTypes.contains(EventType.METRICS) || !metricQueue.offer(objectContainer)) {
             metricLost.incrementAndGet();
           }
         } else if (event instanceof AlertEvent) {
-          if (!alertQueue.offer(objectContainer)) {
+          if (!eventTypes.contains(EventType.ALERTS) || !alertQueue.offer(objectContainer)) {
             alertLost.incrementAndGet();
           }
         } else if (event instanceof RequestLogEvent) {
-          if (config.getRequestTopic() == null || !requestQueue.offer(objectContainer)) {
+          if (!eventTypes.contains(EventType.REQUESTS) || !requestQueue.offer(objectContainer)) {
             requestLost.incrementAndGet();
+          }
+        } else if (event instanceof SegmentMetadataEvent) {
+          if (!eventTypes.contains(EventType.SEGMENTMETADATA)) {
+            segmentMetadataLost.incrementAndGet();
+          } else {
+            switch (config.getSegmentMetadataTopicFormat()) {
+              case PROTOBUF:
+                resultBytes = convertMetadataEventToProto((SegmentMetadataEvent) event, segmentMetadataLost);
+                objectContainer = new ObjectContainer<>(
+                    resultBytes,
+                    resultBytes.length
+                );
+                break;
+              case JSON:
+                // Do Nothing. We already have the JSON object stored in objectContainer
+                break;
+              default:
+                throw new UnsupportedOperationException("segmentMetadata.topic.format has an invalid value " + config.getSegmentMetadataTopicFormat().toString());
+            }
+            if (!segmentMetadataQueue.offer(objectContainer)) {
+              segmentMetadataLost.incrementAndGet();
+            }
           }
         } else {
           invalidLost.incrementAndGet();
         }
       }
-      catch (JsonProcessingException e) {
+      catch (Exception e) {
         invalidLost.incrementAndGet();
+        log.warn(e, "Exception while serializing event");
       }
+    }
+  }
+
+  private byte[] convertMetadataEventToProto(SegmentMetadataEvent event, AtomicLong segmentMetadataLost)
+  {
+    try {
+      Timestamp createdTimeTs = Timestamps.fromMillis(event.getCreatedTime().getMillis());
+      Timestamp startTimeTs = Timestamps.fromMillis(event.getStartTime().getMillis());
+      Timestamp endTimeTs = Timestamps.fromMillis(event.getEndTime().getMillis());
+
+      DruidSegmentEvent.Builder druidSegmentEventBuilder = DruidSegmentEvent.newBuilder()
+          .setDataSource(event.getDataSource())
+          .setCreatedTime(createdTimeTs)
+          .setStartTime(startTimeTs)
+          .setEndTime(endTimeTs)
+          .setVersion(event.getVersion())
+          .setIsCompacted(event.isCompacted());
+      if (config.getClusterName() != null) {
+        druidSegmentEventBuilder.setClusterName(config.getClusterName());
+      }
+      DruidSegmentEvent druidSegmentEvent = druidSegmentEventBuilder.build();
+      return druidSegmentEvent.toByteArray();
+    }
+    catch (Exception e) {
+      log.warn(e, "Exception while serializing SegmentMetadataEvent");
+      throw e;
     }
   }
 
@@ -237,5 +308,10 @@ public class KafkaEmitter implements Emitter
   public long getInvalidLostCount()
   {
     return invalidLost.get();
+  }
+
+  public long getSegmentMetadataLostCount()
+  {
+    return segmentMetadataLost.get();
   }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -21,51 +21,137 @@ package org.apache.druid.emitter.kafka;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
 import javax.annotation.Nullable;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class KafkaEmitterConfig
 {
+  public enum EventType
+  {
+    METRICS,
+    ALERTS,
+    REQUESTS,
+    SEGMENTMETADATA {
+      @Override
+      public String toString()
+      {
+        return "segmentMetadata";
+      }
+    };
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return StringUtils.toLowerCase(this.name());
+    }
+
+    @JsonCreator
+    public static EventType fromString(String name)
+    {
+      return valueOf(StringUtils.toUpperCase(name));
+    }
+  }
+
+  public static final Set<EventType> DEFAULT_EVENT_TYPES = ImmutableSet.of(EventType.ALERTS, EventType.METRICS);
+
+  public enum SegmentMetadataTopicFormat
+  {
+    JSON,
+    PROTOBUF;
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return StringUtils.toLowerCase(this.name());
+    }
+
+    @JsonCreator
+    public static SegmentMetadataTopicFormat fromString(String name)
+    {
+      return valueOf(StringUtils.toUpperCase(name));
+    }
+  }
 
   @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
   private final String bootstrapServers;
-  @JsonProperty("metric.topic")
+  @Nullable @JsonProperty("event.types")
+  private final Set<EventType> eventTypes;
+  @Nullable @JsonProperty("metric.topic")
   private final String metricTopic;
-  @JsonProperty("alert.topic")
+  @Nullable @JsonProperty("alert.topic")
   private final String alertTopic;
   @Nullable @JsonProperty("request.topic")
   private final String requestTopic;
+  @Nullable @JsonProperty("segmentMetadata.topic")
+  private final String segmentMetadataTopic;
+  @Nullable @JsonProperty("segmentMetadata.topic.format")
+  private final SegmentMetadataTopicFormat segmentMetadataTopicFormat;
   @JsonProperty
   private final String clusterName;
   @JsonProperty("producer.config")
-  private Map<String, String> kafkaProducerConfig;
+  private final Map<String, String> kafkaProducerConfig;
 
   @JsonCreator
   public KafkaEmitterConfig(
       @JsonProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) String bootstrapServers,
-      @JsonProperty("metric.topic") String metricTopic,
-      @JsonProperty("alert.topic") String alertTopic,
+      @Nullable @JsonProperty("event.types") Set<EventType> eventTypes,
+      @Nullable @JsonProperty("metric.topic") String metricTopic,
+      @Nullable @JsonProperty("alert.topic") String alertTopic,
       @Nullable @JsonProperty("request.topic") String requestTopic,
+      @Nullable @JsonProperty("segmentMetadata.topic") String segmentMetadataTopic,
+      @Nullable @JsonProperty("segmentMetadata.topic.format") SegmentMetadataTopicFormat segmentMetadataTopicFormat,
       @JsonProperty("clusterName") String clusterName,
       @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig
   )
   {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "bootstrap.servers can not be null");
-    this.metricTopic = Preconditions.checkNotNull(metricTopic, "metric.topic can not be null");
-    this.alertTopic = Preconditions.checkNotNull(alertTopic, "alert.topic can not be null");
-    this.requestTopic = requestTopic;
+    this.eventTypes = validateEventTypes(eventTypes, requestTopic);
+    this.segmentMetadataTopicFormat = segmentMetadataTopicFormat == null ? SegmentMetadataTopicFormat.JSON : segmentMetadataTopicFormat;
+
+    this.metricTopic = this.eventTypes.contains(EventType.METRICS) ? Preconditions.checkNotNull(metricTopic, "metric.topic can not be null") : null;
+    this.alertTopic = this.eventTypes.contains(EventType.ALERTS) ? Preconditions.checkNotNull(alertTopic, "alert.topic can not be null") : null;
+    this.requestTopic = this.eventTypes.contains(EventType.REQUESTS) ? Preconditions.checkNotNull(requestTopic, "request.topic can not be null") : null;
+    this.segmentMetadataTopic = this.eventTypes.contains(EventType.SEGMENTMETADATA) ? Preconditions.checkNotNull(segmentMetadataTopic, "segmentMetadata.topic can not be null") : null;
     this.clusterName = clusterName;
     this.kafkaProducerConfig = kafkaProducerConfig == null ? ImmutableMap.of() : kafkaProducerConfig;
+  }
+
+  private Set<EventType> validateEventTypes(Set<EventType> eventTypes, String requestTopic)
+  {
+    // Unless explicitly overridden, kafka emitter will always emit metrics and alerts
+    if (eventTypes == null) {
+      Set<EventType> defaultEventTypes = new HashSet<>(DEFAULT_EVENT_TYPES);
+      // To maintain backwards compatibility, if eventTypes is not set, then requests are sent out or not
+      // based on the `request.topic` config
+      if (requestTopic != null) {
+        defaultEventTypes.add(EventType.REQUESTS);
+      }
+      return defaultEventTypes;
+    }
+    return eventTypes;
   }
 
   @JsonProperty
   public String getBootstrapServers()
   {
     return bootstrapServers;
+  }
+
+  @JsonProperty
+  public Set<EventType> getEventTypes()
+  {
+    return eventTypes;
   }
 
   @JsonProperty
@@ -92,6 +178,18 @@ public class KafkaEmitterConfig
     return requestTopic;
   }
 
+  @Nullable
+  public String getSegmentMetadataTopic()
+  {
+    return segmentMetadataTopic;
+  }
+
+  @JsonProperty
+  public SegmentMetadataTopicFormat getSegmentMetadataTopicFormat()
+  {
+    return segmentMetadataTopicFormat;
+  }
+
   @JsonProperty
   public Map<String, String> getKafkaProducerConfig()
   {
@@ -113,14 +211,28 @@ public class KafkaEmitterConfig
     if (!getBootstrapServers().equals(that.getBootstrapServers())) {
       return false;
     }
-    if (!getMetricTopic().equals(that.getMetricTopic())) {
+
+    if (getEventTypes() != null ? !getEventTypes().equals(that.getEventTypes()) : that.getEventTypes() != null) {
       return false;
     }
-    if (!getAlertTopic().equals(that.getAlertTopic())) {
+
+    if (getMetricTopic() != null ? !getMetricTopic().equals(that.getMetricTopic()) : that.getMetricTopic() != null) {
+      return false;
+    }
+
+    if (getAlertTopic() != null ? !getAlertTopic().equals(that.getAlertTopic()) : that.getAlertTopic() != null) {
       return false;
     }
 
     if (getRequestTopic() != null ? !getRequestTopic().equals(that.getRequestTopic()) : that.getRequestTopic() != null) {
+      return false;
+    }
+
+    if (getSegmentMetadataTopic() != null ? !getSegmentMetadataTopic().equals(that.getSegmentMetadataTopic()) : that.getSegmentMetadataTopic() != null) {
+      return false;
+    }
+
+    if (getSegmentMetadataTopicFormat() != null ? !getSegmentMetadataTopicFormat().equals(that.getSegmentMetadataTopicFormat()) : that.getSegmentMetadataTopicFormat() != null) {
       return false;
     }
 
@@ -134,9 +246,12 @@ public class KafkaEmitterConfig
   public int hashCode()
   {
     int result = getBootstrapServers().hashCode();
-    result = 31 * result + getMetricTopic().hashCode();
-    result = 31 * result + getAlertTopic().hashCode();
+    result = 31 * result + (getEventTypes() != null ? getEventTypes().hashCode() : 0);
+    result = 31 * result + (getMetricTopic() != null ? getMetricTopic().hashCode() : 0);
+    result = 31 * result + (getAlertTopic() != null ? getAlertTopic().hashCode() : 0);
     result = 31 * result + (getRequestTopic() != null ? getRequestTopic().hashCode() : 0);
+    result = 31 * result + (getSegmentMetadataTopic() != null ? getSegmentMetadataTopic().hashCode() : 0);
+    result = 31 * result + (getSegmentMetadataTopicFormat() != null ? getSegmentMetadataTopicFormat().hashCode() : 0);
     result = 31 * result + (getClusterName() != null ? getClusterName().hashCode() : 0);
     result = 31 * result + getKafkaProducerConfig().hashCode();
     return result;
@@ -147,9 +262,12 @@ public class KafkaEmitterConfig
   {
     return "KafkaEmitterConfig{" +
            "bootstrap.servers='" + bootstrapServers + '\'' +
+           ", event.types='" + eventTypes.toString() + '\'' +
            ", metric.topic='" + metricTopic + '\'' +
            ", alert.topic='" + alertTopic + '\'' +
            ", request.topic='" + requestTopic + '\'' +
+           ", segmentMetadata.topic='" + segmentMetadataTopic + '\'' +
+           ", segmentMetadata.topic.format='" + segmentMetadataTopicFormat + '\'' +
            ", clusterName='" + clusterName + '\'' +
            ", Producer.config=" + kafkaProducerConfig +
            '}';

--- a/extensions-contrib/kafka-emitter/src/main/proto/DruidSegmentEvent.proto
+++ b/extensions-contrib/kafka-emitter/src/main/proto/DruidSegmentEvent.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+import "google/protobuf/timestamp.proto";
+
+option java_multiple_files = true;
+option java_package = "org.apache.druid.emitter.proto";
+option java_outer_classname = "DruidSegmentEventMessage";
+
+/* Druid segment Event used by Druid to publish first level segment information.
+ * The message will be consumed by segment processing app. */
+message DruidSegmentEvent {
+    string dataSource = 1;
+
+    // When this event was created
+    google.protobuf.Timestamp createdTime = 2;
+
+    // Start time of the segment
+    google.protobuf.Timestamp startTime = 3;
+
+    // End time of the segment
+    google.protobuf.Timestamp endTime = 4;
+
+    // Segment version
+    string version = 5;
+
+    // Cluster name
+    string clusterName = 6;
+
+    // Is the segment compacted or not
+    bool isCompacted = 7;
+}

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -19,14 +19,15 @@
 
 package org.apache.druid.emitter.kafka;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
 import java.io.IOException;
 
 public class KafkaEmitterConfigTest
@@ -42,8 +43,8 @@ public class KafkaEmitterConfigTest
   @Test
   public void testSerDeserKafkaEmitterConfig() throws IOException
   {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
-        "alertTest", "requestTest",
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", null, "metricTest",
+        "alertTest", "requestTest", "metadataTest", null,
         "clusterNameTest", ImmutableMap.<String, String>builder()
         .put("testKey", "testValue").build()
     );
@@ -56,8 +57,8 @@ public class KafkaEmitterConfigTest
   @Test
   public void testSerDeserKafkaEmitterConfigNullRequestTopic() throws IOException
   {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", "metricTest",
-        "alertTest", null,
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", null, "metricTest",
+        "alertTest", null, "metadataTest", null,
         "clusterNameTest", ImmutableMap.<String, String>builder()
         .put("testKey", "testValue").build()
     );
@@ -70,8 +71,8 @@ public class KafkaEmitterConfigTest
   @Test
   public void testSerDeNotRequiredKafkaProducerConfig()
   {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", "metricTest",
-        "alertTest", null,
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", null, "metricTest",
+        "alertTest", null, "metadataTest", null,
         "clusterNameTest", null
     );
     try {
@@ -81,6 +82,14 @@ public class KafkaEmitterConfigTest
     catch (NullPointerException e) {
       Assert.fail();
     }
+  }
+
+  @Test
+  public void testDeserializeEventTypesWithDifferentCase() throws JsonProcessingException
+  {
+    Assert.assertEquals(KafkaEmitterConfig.EventType.SEGMENTMETADATA, mapper.readValue("\"segmentMetadata\"", KafkaEmitterConfig.EventType.class));
+    Assert.assertEquals(KafkaEmitterConfig.EventType.ALERTS, mapper.readValue("\"alerts\"", KafkaEmitterConfig.EventType.class));
+    Assert.assertThrows(ValueInstantiationException.class, () -> mapper.readValue("\"segment_metadata\"", KafkaEmitterConfig.EventType.class));
   }
 
   @Test

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.17.0</version>
+    <version>0.19.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>24.0.1</version>
+    <version>24.0.2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -55,6 +55,30 @@
       <version>${project.parent.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -61,6 +61,19 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- jmh -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.27</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.27</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.21.0</version>
+    <version>0.22.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>24.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>24.0.2</version>
+    <version>25.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -56,6 +56,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-indexing-service</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry.proto</groupId>
       <artifactId>opentelemetry-proto</artifactId>
     </dependency>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>24.0.0</version>
+    <version>24.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -35,10 +35,6 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <properties>
-    <protobuf.version>3.2.0</protobuf.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.opencensus</groupId>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.22.1</version>
+    <version>24.0.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <artifactId>druid</artifactId>
     <groupId>org.apache.druid</groupId>
-    <version>0.19.0</version>
+    <version>0.21.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -56,6 +56,15 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry.proto</groupId>
+      <artifactId>opentelemetry-proto</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid.extensions.contrib</groupId>
+      <artifactId>druid-opentelemetry-extensions</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
@@ -75,6 +84,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <scope>provided</scope>
@@ -83,6 +97,18 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid.extensions</groupId>
+      <artifactId>druid-kafka-indexing-service</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${apache.kafka.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- jmh -->

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/KafkaUtils.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/KafkaUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+
+public class KafkaUtils
+{
+  /**
+   * Creates a MethodHandle that – when invoked on a KafkaRecordEntity - returns the given header value
+   * for the underlying KafkaRecordEntity
+   *
+   * The method handle is roughly equivalent to the following function
+   *
+   * (KafkaRecordEntity input) -> {
+   *   Header h = input.getRecord().headers().lastHeader(header)
+   *   if (h != null) {
+   *     return h.value();
+   *   } else {
+   *     return null;
+   *   }
+   * }
+   *
+   * Since KafkaRecordEntity only exists in the kafka-indexing-service plugin classloader,
+   * we need to look up the relevant classes in the classloader where the InputEntity was instantiated.
+   *
+   * The handle returned by this method should be cached for the classloader it was invoked with.
+   *
+   * If the lookup fails for whatever reason, the method handle will always return null;
+   *
+   * @param classLoader the kafka-indexing-service classloader
+   * @param header the header value to look up
+   * @return a MethodHandle
+   */
+  public static MethodHandle lookupGetHeaderMethod(ClassLoader classLoader, String header)
+  {
+    try {
+      Class entityType = Class.forName("org.apache.druid.data.input.kafka.KafkaRecordEntity", true, classLoader);
+      Class recordType = Class.forName("org.apache.kafka.clients.consumer.ConsumerRecord", true, classLoader);
+      Class headersType = Class.forName("org.apache.kafka.common.header.Headers", true, classLoader);
+      Class headerType = Class.forName("org.apache.kafka.common.header.Header", true, classLoader);
+
+      final MethodHandles.Lookup lookup = MethodHandles.lookup();
+      MethodHandle nonNullTest = lookup.findStatic(Objects.class, "nonNull",
+                                                   MethodType.methodType(boolean.class, Object.class)
+      ).asType(MethodType.methodType(boolean.class, headerType));
+
+      final MethodHandle getRecordMethod = lookup.findVirtual(
+          entityType,
+          "getRecord",
+          MethodType.methodType(recordType)
+      );
+      final MethodHandle headersMethod = lookup.findVirtual(recordType, "headers", MethodType.methodType(headersType));
+      final MethodHandle lastHeaderMethod = lookup.findVirtual(
+          headersType,
+          "lastHeader",
+          MethodType.methodType(headerType, String.class)
+      );
+      final MethodHandle valueMethod = lookup.findVirtual(headerType, "value", MethodType.methodType(byte[].class));
+
+      return MethodHandles.filterReturnValue(
+          MethodHandles.filterReturnValue(
+              MethodHandles.filterReturnValue(getRecordMethod, headersMethod),
+              MethodHandles.insertArguments(lastHeaderMethod, 1, header)
+          ),
+          // return null byte array if header is not present
+          MethodHandles.guardWithTest(
+              nonNullTest,
+              valueMethod,
+              // match valueMethod signature by dropping the header instance argument
+              MethodHandles.dropArguments(MethodHandles.constant(byte[].class, null), 0, headerType)
+          )
+      );
+    }
+    catch (ReflectiveOperationException e) {
+      // if lookup fails in the classloader where the InputEntity is defined, then the source may not be
+      // the kafka-indexing-service classloader, or method signatures did not match.
+      // In that case we return a method handle always returning null
+      return noopMethodHandle();
+    }
+  }
+
+  static MethodHandle noopMethodHandle()
+  {
+    return MethodHandles.dropArguments(MethodHandles.constant(byte[].class, null), 0, InputEntity.class);
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/HybridProtobufReader.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opencensus.protobuf;
+
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowListPlusRawValues;
+import org.apache.druid.data.input.KafkaUtils;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.opentelemetry.protobuf.OpenTelemetryMetricsProtobufReader;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class HybridProtobufReader implements InputEntityReader
+{
+  private static final String VERSION_HEADER_KEY = "v";
+  private static final int OPENTELEMETRY_FORMAT_VERSION = 1;
+
+  private final DimensionsSpec dimensionsSpec;
+  private final SettableByteEntity<? extends ByteEntity> source;
+  private final String metricDimension;
+  private final String valueDimension;
+  private final String metricLabelPrefix;
+  private final String resourceLabelPrefix;
+
+  private volatile MethodHandle getHeaderMethod = null;
+
+  enum ProtobufReader
+  {
+    OPENCENSUS,
+    OPENTELEMETRY
+  }
+
+  public HybridProtobufReader(
+      DimensionsSpec dimensionsSpec,
+      SettableByteEntity<? extends ByteEntity> source,
+      String metricDimension,
+      String valueDimension,
+      String metricLabelPrefix,
+      String resourceLabelPrefix
+  )
+  {
+    this.dimensionsSpec = dimensionsSpec;
+    this.source = source;
+    this.metricDimension = metricDimension;
+    this.valueDimension = valueDimension;
+    this.metricLabelPrefix = metricLabelPrefix;
+    this.resourceLabelPrefix = resourceLabelPrefix;
+  }
+
+  @Override
+  public CloseableIterator<InputRow> read() throws IOException
+  {
+    return newReader(whichReader()).read();
+  }
+
+  public InputEntityReader newReader(ProtobufReader which)
+  {
+    switch (which) {
+      case OPENTELEMETRY:
+        return new OpenTelemetryMetricsProtobufReader(
+            dimensionsSpec,
+            source,
+            metricDimension,
+            valueDimension,
+            metricLabelPrefix,
+            resourceLabelPrefix
+        );
+      case OPENCENSUS:
+      default:
+        return new OpenCensusProtobufReader(
+            dimensionsSpec,
+            source,
+            metricDimension,
+            metricLabelPrefix,
+            resourceLabelPrefix
+        );
+    }
+  }
+
+  public ProtobufReader whichReader()
+  {
+    // assume InputEntity is always defined in a single classloader (the kafka-indexing-service classloader)
+    // so we only have to look it up once. To be completely correct we should cache the method based on classloader
+    if (getHeaderMethod == null) {
+      getHeaderMethod = KafkaUtils.lookupGetHeaderMethod(
+          source.getEntity().getClass().getClassLoader(),
+          VERSION_HEADER_KEY
+      );
+    }
+
+    try {
+      byte[] versionHeader = (byte[]) getHeaderMethod.invoke(source.getEntity());
+      if (versionHeader != null) {
+        int version =
+            ByteBuffer.wrap(versionHeader).order(ByteOrder.LITTLE_ENDIAN).getInt();
+        if (version == OPENTELEMETRY_FORMAT_VERSION) {
+          return ProtobufReader.OPENTELEMETRY;
+        }
+      }
+    }
+    catch (Throwable t) {
+      // assume input is opencensus if something went wrong
+    }
+    return ProtobufReader.OPENCENSUS;
+  }
+
+  @Override
+  public CloseableIterator<InputRowListPlusRawValues> sample() throws IOException
+  {
+    return read().map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufExtensionsModule.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufExtensionsModule.java
@@ -37,7 +37,8 @@ public class OpenCensusProtobufExtensionsModule implements DruidModule
     return Collections.singletonList(
         new SimpleModule("OpenCensusProtobufInputRowParserModule")
             .registerSubtypes(
-                new NamedType(OpenCensusProtobufInputRowParser.class, "opencensus-protobuf")
+                new NamedType(OpenCensusProtobufInputRowParser.class, "opencensus-protobuf"),
+                new NamedType(OpenCensusProtobufInputFormat.class, "opencensus-protobuf")
             )
     );
   }

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -24,28 +24,42 @@ import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.KafkaUtils;
 import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.opentelemetry.protobuf.OpenTelemetryMetricsProtobufReader;
 import org.apache.druid.java.util.common.StringUtils;
 
+import javax.annotation.Nullable;
 import java.io.File;
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Objects;
 
 public class OpenCensusProtobufInputFormat implements InputFormat
 {
   private static final String DEFAULT_METRIC_DIMENSION = "name";
   private static final String DEFAULT_RESOURCE_PREFIX = "resource.";
+  private static final String DEFAULT_VALUE_DIMENSION = "value";
+  private static final String VERSION_HEADER_KEY = "v";
+  private static final int OPENTELEMETRY_FORMAT_VERSION = 1;
 
   private final String metricDimension;
+  private final String valueDimension;
   private final String metricLabelPrefix;
   private final String resourceLabelPrefix;
 
+  private volatile MethodHandle getHeaderMethod = null;
+
   public OpenCensusProtobufInputFormat(
       @JsonProperty("metricDimension") String metricDimension,
+      @JsonProperty("valueDimension") @Nullable String valueDimension,
       @JsonProperty("metricLabelPrefix") String metricLabelPrefix,
       @JsonProperty("resourceLabelPrefix") String resourceLabelPrefix
   )
   {
     this.metricDimension = metricDimension != null ? metricDimension : DEFAULT_METRIC_DIMENSION;
+    this.valueDimension = valueDimension != null ? valueDimension : DEFAULT_VALUE_DIMENSION;
     this.metricLabelPrefix = StringUtils.nullToEmptyNonDruidDataString(metricLabelPrefix);
     this.resourceLabelPrefix = resourceLabelPrefix != null ? resourceLabelPrefix : DEFAULT_RESOURCE_PREFIX;
   }
@@ -59,6 +73,37 @@ public class OpenCensusProtobufInputFormat implements InputFormat
   @Override
   public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
   {
+    // assume InputEntity is always defined in a single classloader (the kafka-indexing-service classloader)
+    // so we only have to look it up once. To be completely correct we should cache the method based on classloader
+    if (getHeaderMethod == null) {
+      getHeaderMethod = KafkaUtils.lookupGetHeaderMethod(
+          source.getClass().getClassLoader(),
+          OpenCensusProtobufInputFormat.VERSION_HEADER_KEY
+      );
+    }
+
+    try {
+      byte[] versionHeader = (byte[]) getHeaderMethod.invoke(source);
+      if (versionHeader != null) {
+        int version =
+            ByteBuffer.wrap(versionHeader).order(ByteOrder.LITTLE_ENDIAN).getInt();
+        if (version == OPENTELEMETRY_FORMAT_VERSION) {
+          return new OpenTelemetryMetricsProtobufReader(
+              inputRowSchema.getDimensionsSpec(),
+              (ByteEntity) source,
+              metricDimension,
+              valueDimension,
+              metricLabelPrefix,
+              resourceLabelPrefix
+          );
+        }
+      }
+    }
+    catch (Throwable t) {
+      // assume input is opencensus if something went wrong
+    }
+
+
     return new OpenCensusProtobufReader(
         inputRowSchema.getDimensionsSpec(),
         (ByteEntity) source,

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opencensus.protobuf;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.data.input.InputEntity;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.java.util.common.StringUtils;
+
+import java.io.File;
+import java.util.Objects;
+
+public class OpenCensusProtobufInputFormat implements InputFormat
+{
+  private static final String DEFAULT_METRIC_DIMENSION = "name";
+  private static final String DEFAULT_RESOURCE_PREFIX = "resource.";
+
+  private final String metricDimension;
+  private final String metricLabelPrefix;
+  private final String resourceLabelPrefix;
+
+  public OpenCensusProtobufInputFormat(
+      @JsonProperty("metricDimension") String metricDimension,
+      @JsonProperty("metricLabelPrefix") String metricLabelPrefix,
+      @JsonProperty("resourceLabelPrefix") String resourceLabelPrefix
+  )
+  {
+    this.metricDimension = metricDimension != null ? metricDimension : DEFAULT_METRIC_DIMENSION;
+    this.metricLabelPrefix = StringUtils.nullToEmptyNonDruidDataString(metricLabelPrefix);
+    this.resourceLabelPrefix = resourceLabelPrefix != null ? resourceLabelPrefix : DEFAULT_RESOURCE_PREFIX;
+  }
+
+  @Override
+  public boolean isSplittable()
+  {
+    return false;
+  }
+
+  @Override
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  {
+    return new OpenCensusProtobufReader(
+        inputRowSchema.getDimensionsSpec(),
+        (ByteEntity) source,
+        metricDimension,
+        metricLabelPrefix,
+        resourceLabelPrefix
+    );
+  }
+
+  @JsonProperty
+  public String getMetricDimension()
+  {
+    return metricDimension;
+  }
+
+  @JsonProperty
+  public String getMetricLabelPrefix()
+  {
+    return metricLabelPrefix;
+  }
+
+  @JsonProperty
+  public String getResourceLabelPrefix()
+  {
+    return resourceLabelPrefix;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof OpenCensusProtobufInputFormat)) {
+      return false;
+    }
+    OpenCensusProtobufInputFormat that = (OpenCensusProtobufInputFormat) o;
+    return Objects.equals(metricDimension, that.metricDimension)
+           && Objects.equals(metricLabelPrefix, that.metricLabelPrefix)
+           && Objects.equals(resourceLabelPrefix, that.resourceLabelPrefix);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(metricDimension, metricLabelPrefix, resourceLabelPrefix);
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputFormat.java
@@ -24,16 +24,12 @@ import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
-import org.apache.druid.data.input.KafkaUtils;
 import org.apache.druid.data.input.impl.ByteEntity;
-import org.apache.druid.data.input.opentelemetry.protobuf.OpenTelemetryMetricsProtobufReader;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.lang.invoke.MethodHandle;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Objects;
 
 public class OpenCensusProtobufInputFormat implements InputFormat
@@ -41,15 +37,11 @@ public class OpenCensusProtobufInputFormat implements InputFormat
   private static final String DEFAULT_METRIC_DIMENSION = "name";
   private static final String DEFAULT_RESOURCE_PREFIX = "resource.";
   private static final String DEFAULT_VALUE_DIMENSION = "value";
-  private static final String VERSION_HEADER_KEY = "v";
-  private static final int OPENTELEMETRY_FORMAT_VERSION = 1;
 
   private final String metricDimension;
   private final String valueDimension;
   private final String metricLabelPrefix;
   private final String resourceLabelPrefix;
-
-  private volatile MethodHandle getHeaderMethod = null;
 
   public OpenCensusProtobufInputFormat(
       @JsonProperty("metricDimension") String metricDimension,
@@ -73,41 +65,21 @@ public class OpenCensusProtobufInputFormat implements InputFormat
   @Override
   public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
   {
-    // assume InputEntity is always defined in a single classloader (the kafka-indexing-service classloader)
-    // so we only have to look it up once. To be completely correct we should cache the method based on classloader
-    if (getHeaderMethod == null) {
-      getHeaderMethod = KafkaUtils.lookupGetHeaderMethod(
-          source.getClass().getClassLoader(),
-          OpenCensusProtobufInputFormat.VERSION_HEADER_KEY
-      );
+    // Sampler passes a KafkaRecordEntity directly, while the normal code path wraps the same entity in a
+    // SettableByteEntity
+    SettableByteEntity<? extends ByteEntity> settableEntity;
+    if (source instanceof SettableByteEntity) {
+      settableEntity = (SettableByteEntity<? extends ByteEntity>) source;
+    } else {
+      SettableByteEntity<ByteEntity> wrapper = new SettableByteEntity<>();
+      wrapper.setEntity((ByteEntity) source);
+      settableEntity = wrapper;
     }
-
-    try {
-      byte[] versionHeader = (byte[]) getHeaderMethod.invoke(source);
-      if (versionHeader != null) {
-        int version =
-            ByteBuffer.wrap(versionHeader).order(ByteOrder.LITTLE_ENDIAN).getInt();
-        if (version == OPENTELEMETRY_FORMAT_VERSION) {
-          return new OpenTelemetryMetricsProtobufReader(
-              inputRowSchema.getDimensionsSpec(),
-              (ByteEntity) source,
-              metricDimension,
-              valueDimension,
-              metricLabelPrefix,
-              resourceLabelPrefix
-          );
-        }
-      }
-    }
-    catch (Throwable t) {
-      // assume input is opencensus if something went wrong
-    }
-
-
-    return new OpenCensusProtobufReader(
+    return new HybridProtobufReader(
         inputRowSchema.getDimensionsSpec(),
-        (ByteEntity) source,
+        settableEntity,
         metricDimension,
+        valueDimension,
         metricLabelPrefix,
         resourceLabelPrefix
     );

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
@@ -26,6 +26,7 @@ import org.apache.druid.data.input.ByteBufferInputRowParser;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.ParseSpec;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 
@@ -103,9 +104,11 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
   @Override
   public List<InputRow> parseBatch(ByteBuffer input)
   {
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(input));
     return new OpenCensusProtobufReader(
         parseSpec.getDimensionsSpec(),
-        new ByteEntity(input),
+        settableByteEntity,
         metricDimension,
         metricLabelPrefix,
         resourceLabelPrefix

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
@@ -55,7 +55,7 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
   private static final String DEFAULT_METRIC_DIMENSION = "name";
   private static final String VALUE = "value";
   private static final String TIMESTAMP_COLUMN = "timestamp";
-  private static final String DEFAULT_RESOURCE_PREFIX = "resource.";
+  private static final String DEFAULT_RESOURCE_PREFIX = "";
   private final ParseSpec parseSpec;
   private final List<String> dimensions;
 

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParser.java
@@ -22,45 +22,29 @@ package org.apache.druid.data.input.opencensus.protobuf;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Timestamp;
-import io.opencensus.proto.metrics.v1.LabelKey;
-import io.opencensus.proto.metrics.v1.Metric;
-import io.opencensus.proto.metrics.v1.Point;
-import io.opencensus.proto.metrics.v1.TimeSeries;
 import org.apache.druid.data.input.ByteBufferInputRowParser;
 import org.apache.druid.data.input.InputRow;
-import org.apache.druid.data.input.MapBasedInputRow;
-import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.ParseSpec;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
-import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.utils.CollectionUtils;
 
 import java.nio.ByteBuffer;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
+/**
+ * use {@link OpenCensusProtobufInputFormat} instead
+ */
+@Deprecated
 public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParser
 {
   private static final Logger LOG = new Logger(OpenCensusProtobufInputRowParser.class);
 
-  private static final String SEPARATOR = "-";
-  private static final String VALUE_COLUMN = "value";
   private static final String DEFAULT_METRIC_DIMENSION = "name";
   private static final String DEFAULT_RESOURCE_PREFIX = "";
 
   private final ParseSpec parseSpec;
-  private final DimensionsSpec dimensionsSpec;
 
   private final String metricDimension;
   private final String metricLabelPrefix;
@@ -75,7 +59,6 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
   )
   {
     this.parseSpec = parseSpec;
-    this.dimensionsSpec = parseSpec.getDimensionsSpec();
     this.metricDimension = Strings.isNullOrEmpty(metricDimension) ? DEFAULT_METRIC_DIMENSION : metricDimension;
     this.metricLabelPrefix = StringUtils.nullToEmptyNonDruidDataString(metricPrefix);
     this.resourceLabelPrefix = resourcePrefix != null ? resourcePrefix : DEFAULT_RESOURCE_PREFIX;
@@ -117,127 +100,16 @@ public class OpenCensusProtobufInputRowParser implements ByteBufferInputRowParse
         resourceLabelPrefix);
   }
 
-
-  private interface LabelContext
-  {
-    void addRow(long millis, String metricName, Object value);
-  }
-
   @Override
   public List<InputRow> parseBatch(ByteBuffer input)
   {
-    final Metric metric;
-    try {
-      metric = Metric.parseFrom(input);
-    }
-    catch (InvalidProtocolBufferException e) {
-      throw new ParseException(e, "Protobuf message could not be parsed");
-    }
-
-    // Process metric descriptor labels map keys.
-    List<String> descriptorLabels = new ArrayList<>(metric.getMetricDescriptor().getLabelKeysCount());
-    for (LabelKey s : metric.getMetricDescriptor().getLabelKeysList()) {
-      descriptorLabels.add(this.metricLabelPrefix + s.getKey());
-    }
-
-    // Process resource labels map.
-    Map<String, String> resourceLabelsMap = CollectionUtils.mapKeys(
-        metric.getResource().getLabelsMap(),
-        key -> this.resourceLabelPrefix + key
-    );
-
-    final List<String> schemaDimensions = dimensionsSpec.getDimensionNames();
-
-    final List<String> dimensions;
-    if (!schemaDimensions.isEmpty()) {
-      dimensions = schemaDimensions;
-    } else {
-      Set<String> recordDimensions = new HashSet<>(descriptorLabels);
-
-      // Add resource map key set to record dimensions.
-      recordDimensions.addAll(resourceLabelsMap.keySet());
-
-      // MetricDimension, VALUE dimensions will not be present in labelKeysList or Metric.Resource
-      // map as they are derived dimensions, which get populated while parsing data for timeSeries
-      // hence add them to recordDimensions.
-      recordDimensions.add(metricDimension);
-      recordDimensions.add(VALUE_COLUMN);
-
-      dimensions = Lists.newArrayList(
-          Sets.difference(recordDimensions, dimensionsSpec.getDimensionExclusions())
-      );
-    }
-
-    final int capacity = resourceLabelsMap.size()
-                         + descriptorLabels.size()
-                         + 2; // metric name + value columns
-
-    List<InputRow> rows = new ArrayList<>();
-    for (TimeSeries ts : metric.getTimeseriesList()) {
-      final LabelContext labelContext = (millis, metricName, value) -> {
-        // Add common resourceLabels.
-        Map<String, Object> event = new HashMap<>(capacity);
-        event.putAll(resourceLabelsMap);
-        // Add metric labels
-        for (int i = 0; i < metric.getMetricDescriptor().getLabelKeysCount(); i++) {
-          event.put(descriptorLabels.get(i), ts.getLabelValues(i).getValue());
-        }
-        // add metric name and value
-        event.put(metricDimension, metricName);
-        event.put(VALUE_COLUMN, value);
-        rows.add(new MapBasedInputRow(millis, dimensions, event));
-      };
-
-      for (Point point : ts.getPointsList()) {
-        addPointRows(point, metric, labelContext);
-      }
-    }
-    return rows;
-  }
-
-  private void addPointRows(Point point, Metric metric, LabelContext labelContext)
-  {
-    Timestamp timestamp = point.getTimestamp();
-    long millis = Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()).toEpochMilli();
-    String metricName = metric.getMetricDescriptor().getName();
-
-    switch (point.getValueCase()) {
-      case DOUBLE_VALUE:
-        labelContext.addRow(millis, metricName, point.getDoubleValue());
-        break;
-
-      case INT64_VALUE:
-        labelContext.addRow(millis, metricName, point.getInt64Value());
-        break;
-
-      case SUMMARY_VALUE:
-        // count
-        labelContext.addRow(
-            millis,
-            metricName + SEPARATOR + "count",
-            point.getSummaryValue().getCount().getValue()
-        );
-        // sum
-        labelContext.addRow(
-            millis,
-            metricName + SEPARATOR + "sum",
-            point.getSummaryValue().getSnapshot().getSum().getValue()
-        );
-        break;
-
-      // TODO : How to handle buckets and percentiles
-      case DISTRIBUTION_VALUE:
-        // count
-        labelContext.addRow(millis, metricName + SEPARATOR + "count", point.getDistributionValue().getCount());
-        // sum
-        labelContext.addRow(
-            millis,
-            metricName + SEPARATOR + "sum",
-            point.getDistributionValue().getSum()
-        );
-        break;
-      default:
-    }
+    return new OpenCensusProtobufReader(
+        parseSpec.getDimensionsSpec(),
+        new ByteEntity(input),
+        metricDimension,
+        metricLabelPrefix,
+        resourceLabelPrefix
+    ).readAsList();
   }
 
   @Override

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -86,11 +86,13 @@ public class OpenCensusProtobufReader implements InputEntityReader
     Supplier<Iterator<InputRow>> supplier = Suppliers.memoize(() -> readAsList().iterator());
     return CloseableIterators.withEmptyBaggage(new Iterator<InputRow>() {
       @Override
-      public boolean hasNext() {
+      public boolean hasNext()
+      {
         return supplier.get().hasNext();
       }
       @Override
-      public InputRow next() {
+      public InputRow next()
+      {
         return supplier.get().next();
       }
     });

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -20,6 +20,7 @@
 package org.apache.druid.data.input.opencensus.protobuf;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
@@ -40,7 +41,6 @@ import org.apache.druid.utils.CollectionUtils;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -137,7 +137,7 @@ public class OpenCensusProtobufReader implements InputEntityReader
     for (TimeSeries ts : metric.getTimeseriesList()) {
       final LabelContext labelContext = (millis, metricName, value) -> {
         // Add common resourceLabels.
-        Map<String, Object> event = new HashMap<>(capacity);
+        Map<String, Object> event = Maps.newHashMapWithExpectedSize(capacity);
         event.putAll(resourceLabelsMap);
         // Add metric labels
         for (int i = 0; i < metric.getMetricDescriptor().getLabelKeysCount(); i++) {

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opencensus.protobuf;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Timestamp;
+import io.opencensus.proto.metrics.v1.LabelKey;
+import io.opencensus.proto.metrics.v1.Metric;
+import io.opencensus.proto.metrics.v1.Point;
+import io.opencensus.proto.metrics.v1.TimeSeries;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowListPlusRawValues;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.java.util.common.CloseableIterators;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.ParseException;
+import org.apache.druid.utils.CollectionUtils;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class OpenCensusProtobufReader implements InputEntityReader
+{
+  private static final String SEPARATOR = "-";
+  private static final String VALUE_COLUMN = "value";
+
+  private final DimensionsSpec dimensionsSpec;
+  private final ByteEntity source;
+  private final String metricDimension;
+  private final String metricLabelPrefix;
+  private final String resourceLabelPrefix;
+
+  public OpenCensusProtobufReader(
+      DimensionsSpec dimensionsSpec,
+      ByteEntity source,
+      String metricDimension,
+      String metricLabelPrefix,
+      String resourceLabelPrefix
+  )
+  {
+    this.dimensionsSpec = dimensionsSpec;
+    this.source = source;
+    this.metricDimension = metricDimension;
+    this.metricLabelPrefix = metricLabelPrefix;
+    this.resourceLabelPrefix = resourceLabelPrefix;
+  }
+
+  private interface LabelContext
+  {
+    void addRow(long millis, String metricName, Object value);
+  }
+
+  @Override
+  public CloseableIterator<InputRow> read()
+  {
+    return CloseableIterators.withEmptyBaggage(readAsList().iterator());
+  }
+
+  List<InputRow> readAsList()
+  {
+    try {
+      return parseMetric(Metric.parseFrom(source.getBuffer()));
+    }
+    catch (InvalidProtocolBufferException e) {
+      throw new ParseException(e, "Protobuf message could not be parsed");
+    }
+  }
+
+  private List<InputRow> parseMetric(final Metric metric)
+  {
+    // Process metric descriptor labels map keys.
+    List<String> descriptorLabels = new ArrayList<>(metric.getMetricDescriptor().getLabelKeysCount());
+    for (LabelKey s : metric.getMetricDescriptor().getLabelKeysList()) {
+      descriptorLabels.add(this.metricLabelPrefix + s.getKey());
+    }
+
+    // Process resource labels map.
+    Map<String, String> resourceLabelsMap = CollectionUtils.mapKeys(
+        metric.getResource().getLabelsMap(),
+        key -> this.resourceLabelPrefix + key
+    );
+
+    final List<String> schemaDimensions = dimensionsSpec.getDimensionNames();
+
+    final List<String> dimensions;
+    if (!schemaDimensions.isEmpty()) {
+      dimensions = schemaDimensions;
+    } else {
+      Set<String> recordDimensions = new HashSet<>(descriptorLabels);
+
+      // Add resource map key set to record dimensions.
+      recordDimensions.addAll(resourceLabelsMap.keySet());
+
+      // MetricDimension, VALUE dimensions will not be present in labelKeysList or Metric.Resource
+      // map as they are derived dimensions, which get populated while parsing data for timeSeries
+      // hence add them to recordDimensions.
+      recordDimensions.add(metricDimension);
+      recordDimensions.add(VALUE_COLUMN);
+
+      dimensions = Lists.newArrayList(
+          Sets.difference(recordDimensions, dimensionsSpec.getDimensionExclusions())
+      );
+    }
+
+    final int capacity = resourceLabelsMap.size()
+                         + descriptorLabels.size()
+                         + 2; // metric name + value columns
+
+    List<InputRow> rows = new ArrayList<>();
+    for (TimeSeries ts : metric.getTimeseriesList()) {
+      final LabelContext labelContext = (millis, metricName, value) -> {
+        // Add common resourceLabels.
+        Map<String, Object> event = new HashMap<>(capacity);
+        event.putAll(resourceLabelsMap);
+        // Add metric labels
+        for (int i = 0; i < metric.getMetricDescriptor().getLabelKeysCount(); i++) {
+          event.put(descriptorLabels.get(i), ts.getLabelValues(i).getValue());
+        }
+        // add metric name and value
+        event.put(metricDimension, metricName);
+        event.put(VALUE_COLUMN, value);
+        rows.add(new MapBasedInputRow(millis, dimensions, event));
+      };
+
+      for (Point point : ts.getPointsList()) {
+        addPointRows(point, metric, labelContext);
+      }
+    }
+    return rows;
+  }
+
+  private void addPointRows(Point point, Metric metric, LabelContext labelContext)
+  {
+    Timestamp timestamp = point.getTimestamp();
+    long millis = Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos()).toEpochMilli();
+    String metricName = metric.getMetricDescriptor().getName();
+
+    switch (point.getValueCase()) {
+      case DOUBLE_VALUE:
+        labelContext.addRow(millis, metricName, point.getDoubleValue());
+        break;
+
+      case INT64_VALUE:
+        labelContext.addRow(millis, metricName, point.getInt64Value());
+        break;
+
+      case SUMMARY_VALUE:
+        // count
+        labelContext.addRow(
+            millis,
+            metricName + SEPARATOR + "count",
+            point.getSummaryValue().getCount().getValue()
+        );
+        // sum
+        labelContext.addRow(
+            millis,
+            metricName + SEPARATOR + "sum",
+            point.getSummaryValue().getSnapshot().getSum().getValue()
+        );
+        break;
+
+      // TODO : How to handle buckets and percentiles
+      case DISTRIBUTION_VALUE:
+        // count
+        labelContext.addRow(millis, metricName + SEPARATOR + "count", point.getDistributionValue().getCount());
+        // sum
+        labelContext.addRow(
+            millis,
+            metricName + SEPARATOR + "sum",
+            point.getDistributionValue().getSum()
+        );
+        break;
+      default:
+    }
+  }
+
+  @Override
+  public CloseableIterator<InputRowListPlusRawValues> sample()
+  {
+    return read().map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
+++ b/extensions-contrib/opencensus-extensions/src/main/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReader.java
@@ -89,7 +89,7 @@ public class OpenCensusProtobufReader implements InputEntityReader
       return parseMetric(Metric.parseFrom(source.getBuffer()));
     }
     catch (InvalidProtocolBufferException e) {
-      throw new ParseException(e, "Protobuf message could not be parsed");
+      throw new ParseException(null, e, "Protobuf message could not be parsed");
     }
   }
 

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/KafkaUtilsTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/KafkaUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input;
+
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.nio.ByteBuffer;
+
+public class KafkaUtilsTest
+{
+
+  private static final byte[] BYTES = ByteBuffer.allocate(Integer.BYTES).putInt(42).array();
+
+  @Test
+  public void testNoopMethodHandle() throws Throwable
+  {
+    Assert.assertNull(
+        KafkaUtils.noopMethodHandle().invoke(new ByteEntity(new byte[]{}))
+    );
+  }
+
+  @Test
+  public void testKafkaRecordEntity() throws Throwable
+  {
+    final MethodHandle handle = KafkaUtils.lookupGetHeaderMethod(KafkaUtilsTest.class.getClassLoader(), "version");
+    KafkaRecordEntity input = new KafkaRecordEntity(
+        new ConsumerRecord<>(
+            "test",
+            0,
+            0,
+            0,
+            TimestampType.CREATE_TIME,
+            -1L,
+            -1,
+            -1,
+            null,
+            new byte[]{},
+            new RecordHeaders(ImmutableList.of(new Header()
+            {
+              @Override
+              public String key()
+              {
+                return "version";
+              }
+
+              @Override
+              public byte[] value()
+              {
+                return BYTES;
+              }
+            }))
+        )
+    );
+    Assert.assertArrayEquals(BYTES, (byte[]) handle.invoke(input));
+  }
+
+  @Test(expected = ClassCastException.class)
+  public void testNonKafkaEntity() throws Throwable
+  {
+    final MethodHandle handle = KafkaUtils.lookupGetHeaderMethod(KafkaUtilsTest.class.getClassLoader(), "version");
+    handle.invoke(new ByteEntity(new byte[]{}));
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusBenchmark.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusBenchmark.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opencensus.protobuf;
+
+import com.google.common.collect.Lists;
+import com.google.protobuf.Timestamp;
+import io.opencensus.proto.metrics.v1.LabelKey;
+import io.opencensus.proto.metrics.v1.LabelValue;
+import io.opencensus.proto.metrics.v1.Metric;
+import io.opencensus.proto.metrics.v1.MetricDescriptor;
+import io.opencensus.proto.metrics.v1.Point;
+import io.opencensus.proto.metrics.v1.TimeSeries;
+import io.opencensus.proto.resource.v1.Resource;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.JSONParseSpec;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@Fork(1)
+public class OpenCensusBenchmark
+{
+  private static final Instant INSTANT = Instant.parse("2019-07-12T09:30:01.123Z");
+  private static final Timestamp TIMESTAMP = Timestamp.newBuilder()
+                                                      .setSeconds(INSTANT.getEpochSecond())
+                                                      .setNanos(INSTANT.getNano()).build();
+
+  private static final JSONParseSpec PARSE_SPEC = new JSONParseSpec(
+      new TimestampSpec("timestamp", "millis", null),
+      new DimensionsSpec(null, null, null),
+      new JSONPathSpec(
+          true,
+          Lists.newArrayList(
+              new JSONPathFieldSpec(JSONPathFieldType.ROOT, "name", ""),
+              new JSONPathFieldSpec(JSONPathFieldType.ROOT, "value", ""),
+              new JSONPathFieldSpec(JSONPathFieldType.ROOT, "foo_key", "")
+          )
+      ), null, null
+  );
+
+  private static final OpenCensusProtobufInputRowParser PARSER = new OpenCensusProtobufInputRowParser(PARSE_SPEC, null, null, "");
+
+  private static final ByteBuffer BUFFER = ByteBuffer.wrap(createMetric().toByteArray());
+
+  static Metric createMetric()
+  {
+    final MetricDescriptor.Builder descriptorBuilder = MetricDescriptor.newBuilder()
+                                                        .setName("io.confluent.domain/such/good/metric/wow")
+                                                        .setUnit("ms")
+                                                        .setType(MetricDescriptor.Type.CUMULATIVE_DOUBLE);
+
+
+    final TimeSeries.Builder tsBuilder = TimeSeries.newBuilder()
+                                                   .setStartTimestamp(TIMESTAMP)
+                                                   .addPoints(Point.newBuilder().setDoubleValue(42.0).build());
+    for (int i = 0; i < 10; i++) {
+      descriptorBuilder.addLabelKeys(LabelKey.newBuilder()
+                                             .setKey("foo_key_" + i)
+                                             .build());
+      tsBuilder.addLabelValues(LabelValue.newBuilder()
+                                         .setHasValue(true)
+                                         .setValue("foo_value")
+                                         .build());
+    }
+
+    final Map<String, String> resourceLabels = new HashMap<>();
+    for (int i = 0; i < 5; i++) {
+      resourceLabels.put("resoure.label_" + i, "val_" + i);
+    }
+
+    return Metric.newBuilder()
+                 .setMetricDescriptor(descriptorBuilder.build())
+                 .setResource(
+                     Resource.newBuilder()
+                             .setType("env")
+                             .putAllLabels(resourceLabels)
+                             .build())
+                 .addTimeseries(tsBuilder.build())
+                 .build();
+  }
+
+  @Benchmark()
+  public void measureSerde(Blackhole blackhole)
+  {
+    // buffer must be reset / duplicated each time to ensure each iteration reads the entire buffer from the beginning
+    for (InputRow row : PARSER.parseBatch(BUFFER.duplicate())) {
+      blackhole.consume(row);
+    }
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusBenchmark.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusBenchmark.java
@@ -41,6 +41,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,7 +55,7 @@ public class OpenCensusBenchmark
 
   private static final JSONParseSpec PARSE_SPEC = new JSONParseSpec(
       new TimestampSpec("timestamp", "millis", null),
-      new DimensionsSpec(null, null, null),
+      new DimensionsSpec(Collections.emptyList()),
       new JSONPathSpec(
           true,
           Lists.newArrayList(

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusInputFormatTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusInputFormatTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opencensus.protobuf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.InputFormat;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OpenCensusInputFormatTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name", "descriptor.", "custom.");
+
+    final ObjectMapper jsonMapper = new ObjectMapper();
+    jsonMapper.registerModules(new OpenCensusProtobufExtensionsModule().getJacksonModules());
+
+    final OpenCensusProtobufInputFormat actual = (OpenCensusProtobufInputFormat) jsonMapper.readValue(
+        jsonMapper.writeValueAsString(inputFormat),
+        InputFormat.class
+    );
+    Assert.assertEquals(inputFormat, actual);
+    Assert.assertEquals("metric.name", actual.getMetricDimension());
+    Assert.assertEquals("descriptor.", actual.getMetricLabelPrefix());
+    Assert.assertEquals("custom.", actual.getResourceLabelPrefix());
+  }
+
+  @Test
+  public void testDefaults()
+  {
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat(null, null, null);
+
+    Assert.assertEquals("name", inputFormat.getMetricDimension());
+    Assert.assertEquals("", inputFormat.getMetricLabelPrefix());
+    Assert.assertEquals("resource.", inputFormat.getResourceLabelPrefix());
+  }
+}

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusInputFormatTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusInputFormatTest.java
@@ -29,7 +29,7 @@ public class OpenCensusInputFormatTest
   @Test
   public void testSerde() throws Exception
   {
-    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name", "descriptor.", "custom.");
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name", null, "descriptor.", "custom.");
 
     final ObjectMapper jsonMapper = new ObjectMapper();
     jsonMapper.registerModules(new OpenCensusProtobufExtensionsModule().getJacksonModules());
@@ -47,7 +47,7 @@ public class OpenCensusInputFormatTest
   @Test
   public void testDefaults()
   {
-    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat(null, null, null);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat(null, null, null, null);
 
     Assert.assertEquals("name", inputFormat.getMetricDimension());
     Assert.assertEquals("", inputFormat.getMetricLabelPrefix());

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
@@ -80,7 +80,7 @@ public class OpenCensusProtobufInputRowParserTest
                 new JSONPathFieldSpec(JSONPathFieldType.ROOT, "value", ""),
                 new JSONPathFieldSpec(JSONPathFieldType.ROOT, "foo_key", "")
             )
-        ), null
+        ), null, null
     );
 
     parseSpecWithDimensions = new JSONParseSpec(
@@ -95,7 +95,7 @@ public class OpenCensusProtobufInputRowParserTest
                 new JSONPathFieldSpec(JSONPathFieldType.ROOT, "value", ""),
                 new JSONPathFieldSpec(JSONPathFieldType.ROOT, "foo_key", "")
             )
-        ), null
+        ), null, null
     );
   }
 

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
@@ -63,7 +63,7 @@ public class OpenCensusProtobufInputRowParserTest
 
   static final JSONParseSpec PARSE_SPEC = new JSONParseSpec(
       new TimestampSpec("timestamp", "millis", null),
-      new DimensionsSpec(null, null, null),
+      new DimensionsSpec(Collections.emptyList()),
       new JSONPathSpec(
           true,
           Lists.newArrayList(
@@ -79,7 +79,7 @@ public class OpenCensusProtobufInputRowParserTest
       new DimensionsSpec(ImmutableList.of(
           new StringDimensionSchema("foo_key"),
           new StringDimensionSchema("env_key")
-      ), null, null),
+      )),
       new JSONPathSpec(
           true,
           Lists.newArrayList(

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufInputRowParserTest.java
@@ -322,13 +322,13 @@ public class OpenCensusProtobufInputRowParserTest
     Assert.assertEquals(4, row.getDimensions().size());
     assertDimensionEquals(row, "name", "metric_summary-count");
     assertDimensionEquals(row, "foo_key", "foo_value");
-    assertDimensionEquals(row, "resource.env_key", "env_val");
+    assertDimensionEquals(row, "env_key", "env_val");
 
     row = rows.get(1);
     Assert.assertEquals(4, row.getDimensions().size());
     assertDimensionEquals(row, "name", "metric_summary-sum");
     assertDimensionEquals(row, "foo_key", "foo_value");
-    assertDimensionEquals(row, "resource.env_key", "env_val");
+    assertDimensionEquals(row, "env_key", "env_val");
   }
 
   @Test

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
@@ -63,8 +63,8 @@ public class OpenCensusProtobufReaderTest
   public static final String RESOURCE_ATTRIBUTE_ENV = "env";
   public static final String RESOURCE_ATTRIBUTE_VALUE_DEVEL = "devel";
 
-  public static final String INSTRUMENTATION_LIBRARY_NAME = "mock-instr-lib";
-  public static final String INSTRUMENTATION_LIBRARY_VERSION = "1.0";
+  public static final String INSTRUMENTATION_SCOPE_NAME = "mock-instr-lib";
+  public static final String INSTRUMENTATION_SCOPE_VERSION = "1.0";
 
   public static final String METRIC_ATTRIBUTE_COLOR = "color";
   public static final String METRIC_ATTRIBUTE_VALUE_RED = "red";
@@ -75,7 +75,7 @@ public class OpenCensusProtobufReaderTest
   private final MetricsData.Builder metricsDataBuilder = MetricsData.newBuilder();
 
   private final Metric.Builder metricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
-      .addInstrumentationLibraryMetricsBuilder()
+      .addScopeMetricsBuilder()
       .addMetricsBuilder();
 
   private final DimensionsSpec dimensionsSpec = new DimensionsSpec(ImmutableList.of(
@@ -109,10 +109,10 @@ public class OpenCensusProtobufReaderTest
 
     metricsDataBuilder
       .getResourceMetricsBuilder(0)
-      .getInstrumentationLibraryMetricsBuilder(0)
-      .getInstrumentationLibraryBuilder()
-      .setName(INSTRUMENTATION_LIBRARY_NAME)
-      .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+      .getScopeMetricsBuilder(0)
+      .getScopeBuilder()
+      .setName(INSTRUMENTATION_SCOPE_NAME)
+      .setVersion(INSTRUMENTATION_SCOPE_VERSION);
 
   }
 
@@ -215,7 +215,7 @@ public class OpenCensusProtobufReaderTest
 
     // Create Second Metric
     Metric.Builder gaugeMetricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
-        .addInstrumentationLibraryMetricsBuilder()
+        .addScopeMetricsBuilder()
         .addMetricsBuilder();
 
     metricsDataBuilder.getResourceMetricsBuilder(1)
@@ -226,10 +226,10 @@ public class OpenCensusProtobufReaderTest
           .build());
 
     metricsDataBuilder.getResourceMetricsBuilder(1)
-      .getInstrumentationLibraryMetricsBuilder(0)
-      .getInstrumentationLibraryBuilder()
-      .setName(INSTRUMENTATION_LIBRARY_NAME)
-      .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+      .getScopeMetricsBuilder(0)
+      .getScopeBuilder()
+      .setName(INSTRUMENTATION_SCOPE_NAME)
+      .setVersion(INSTRUMENTATION_SCOPE_VERSION);
 
     gaugeMetricBuilder.setName("example_gauge")
       .getGaugeBuilder()

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenCensusProtobufReaderTest.java
@@ -327,8 +327,9 @@ public class OpenCensusProtobufReaderTest
   }
 
   @Test
-  public void testInvalidProtobuf() throws IOException {
-    byte[] invalidProtobuf = new byte[] { 0x00, 0x01 };
+  public void testInvalidProtobuf() throws IOException
+  {
+    byte[] invalidProtobuf = new byte[] {0x00, 0x01};
     ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,
         -1L, -1, -1, null, invalidProtobuf, HEADERS);
     KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -81,7 +81,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
       new StringDimensionSchema("descriptor." + METRIC_ATTRIBUTE_FOO_KEY),
       new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_ENV),
       new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_COUNTRY)
-  ), null, null);
+  ));
 
   public static final String TOPIC = "telemetry.metrics.otel";
   public static final int PARTITION = 2;
@@ -291,11 +291,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
             .setKey(METRIC_ATTRIBUTE_FOO_KEY)
             .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_FOO_VAL).build()).build()));
 
-    DimensionsSpec dimensionsSpecWithExclusions = new DimensionsSpec(null,
+    DimensionsSpec dimensionsSpecWithExclusions = DimensionsSpec.builder().setDimensionExclusions(
         ImmutableList.of(
           "descriptor." + METRIC_ATTRIBUTE_COLOR,
           "custom." + RESOURCE_ATTRIBUTE_COUNTRY
-        ), null);
+        )).build();
 
     MetricsData metricsData = metricsDataBuilder.build();
     ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -24,6 +24,7 @@ import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.MetricsData;
+import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -48,7 +49,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -144,7 +144,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
     CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
         new TimestampSpec("timestamp", "iso", null),
         dimensionsSpec,
-        Collections.emptyList()
+        ColumnsFilter.all()
       ), kafkaRecordEntity, null).read();
 
     List<InputRow> rowList = new ArrayList<>();
@@ -182,7 +182,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
     CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
         new TimestampSpec("timestamp", "iso", null),
         dimensionsSpec,
-        Collections.emptyList()
+        ColumnsFilter.all()
     ), kafkaRecordEntity, null).read();
 
     Assert.assertTrue(rows.hasNext());
@@ -246,7 +246,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
     CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
         new TimestampSpec("timestamp", "iso", null),
         dimensionsSpec,
-        Collections.emptyList()
+        ColumnsFilter.all()
     ), kafkaRecordEntity, null).read();
 
 
@@ -309,7 +309,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
     CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
         new TimestampSpec("timestamp", "iso", null),
         dimensionsSpecWithExclusions,
-        Collections.emptyList()
+        ColumnsFilter.all()
     ), kafkaRecordEntity, null).read();
 
 

--- a/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opencensus-extensions/src/test/java/org/apache/druid/data/input/opencensus/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opencensus.protobuf;
+
+import com.google.common.collect.ImmutableList;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.data.input.kafka.KafkaRecordEntity;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class OpenTelemetryMetricsProtobufReaderTest
+{
+  private static final long TIMESTAMP = TimeUnit.MILLISECONDS.toNanos(Instant.parse("2019-07-12T09:30:01.123Z").toEpochMilli());
+  public static final String RESOURCE_ATTRIBUTE_COUNTRY = "country";
+  public static final String RESOURCE_ATTRIBUTE_VALUE_USA = "usa";
+
+  public static final String RESOURCE_ATTRIBUTE_ENV = "env";
+  public static final String RESOURCE_ATTRIBUTE_VALUE_DEVEL = "devel";
+
+  public static final String INSTRUMENTATION_LIBRARY_NAME = "mock-instr-lib";
+  public static final String INSTRUMENTATION_LIBRARY_VERSION = "1.0";
+
+  public static final String METRIC_ATTRIBUTE_COLOR = "color";
+  public static final String METRIC_ATTRIBUTE_VALUE_RED = "red";
+
+  public static final String METRIC_ATTRIBUTE_FOO_KEY = "foo_key";
+  public static final String METRIC_ATTRIBUTE_FOO_VAL = "foo_value";
+
+  private final MetricsData.Builder metricsDataBuilder = MetricsData.newBuilder();
+
+  private final Metric.Builder metricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
+      .addInstrumentationLibraryMetricsBuilder()
+      .addMetricsBuilder();
+
+  private final DimensionsSpec dimensionsSpec = new DimensionsSpec(ImmutableList.of(
+      new StringDimensionSchema("descriptor." + METRIC_ATTRIBUTE_COLOR),
+      new StringDimensionSchema("descriptor." + METRIC_ATTRIBUTE_FOO_KEY),
+      new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_ENV),
+      new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_COUNTRY)
+  ), null, null);
+
+  public static final String TOPIC = "telemetry.metrics.otel";
+  public static final int PARTITION = 2;
+  public static final long OFFSET = 13095752723L;
+  public static final long TS = 1643974867555L;
+  public static final TimestampType TSTYPE = TimestampType.CREATE_TIME;
+  public static final byte[] V0_HEADER_BYTES = ByteBuffer.allocate(Integer.BYTES)
+    .order(ByteOrder.LITTLE_ENDIAN)
+    .putInt(1)
+    .array();
+  private static final Header HEADERV1 = new RecordHeader("v", V0_HEADER_BYTES);
+  private static final Headers HEADERS = new RecordHeaders(new Header[]{HEADERV1});
+
+
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setUp()
+  {
+    metricsDataBuilder
+        .getResourceMetricsBuilder(0)
+        .getResourceBuilder()
+        .addAttributes(KeyValue.newBuilder()
+          .setKey(RESOURCE_ATTRIBUTE_COUNTRY)
+          .setValue(AnyValue.newBuilder().setStringValue(RESOURCE_ATTRIBUTE_VALUE_USA)));
+
+    metricsDataBuilder
+      .getResourceMetricsBuilder(0)
+      .getInstrumentationLibraryMetricsBuilder(0)
+      .getInstrumentationLibraryBuilder()
+      .setName(INSTRUMENTATION_LIBRARY_NAME)
+      .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+
+  }
+
+  @Test
+  public void testSumWithAttributes() throws IOException
+  {
+    metricBuilder
+      .setName("example_sum")
+      .getSumBuilder()
+      .addDataPointsBuilder()
+      .setAsInt(6)
+      .setTimeUnixNano(TIMESTAMP)
+      .addAttributesBuilder() // test sum with attributes
+      .setKey(METRIC_ATTRIBUTE_COLOR)
+      .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
+
+    MetricsData metricsData = metricsDataBuilder.build();
+    ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,
+         -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
+    KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        null,
+        "descriptor.",
+        "custom.");
+
+    CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
+        new TimestampSpec("timestamp", "iso", null),
+        dimensionsSpec,
+        Collections.emptyList()
+      ), kafkaRecordEntity, null).read();
+
+    List<InputRow> rowList = new ArrayList<>();
+    rows.forEachRemaining(rowList::add);
+    Assert.assertEquals(1, rowList.size());
+
+    InputRow row = rowList.get(0);
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_sum");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+    assertDimensionEquals(row, "value", "6");
+  }
+
+  @Test
+  public void testGaugeWithAttributes() throws IOException
+  {
+    metricBuilder.setName("example_gauge")
+      .getGaugeBuilder()
+      .addDataPointsBuilder()
+      .setAsInt(6)
+      .setTimeUnixNano(TIMESTAMP)
+      .addAttributesBuilder() // test sum with attributes
+      .setKey(METRIC_ATTRIBUTE_COLOR)
+      .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
+
+    MetricsData metricsData = metricsDataBuilder.build();
+    ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,
+        -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
+    KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        null,
+        "descriptor.",
+        "custom.");
+    CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
+        new TimestampSpec("timestamp", "iso", null),
+        dimensionsSpec,
+        Collections.emptyList()
+    ), kafkaRecordEntity, null).read();
+
+    Assert.assertTrue(rows.hasNext());
+    InputRow row = rows.next();
+
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_gauge");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+    assertDimensionEquals(row, "value", "6");
+  }
+
+  @Test
+  public void testBatchedMetricParse() throws IOException
+  {
+    metricBuilder.setName("example_sum")
+      .getSumBuilder()
+      .addDataPointsBuilder()
+      .setAsInt(6)
+      .setTimeUnixNano(TIMESTAMP)
+      .addAttributesBuilder() // test sum with attributes
+      .setKey(METRIC_ATTRIBUTE_COLOR)
+      .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
+
+    // Create Second Metric
+    Metric.Builder gaugeMetricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
+        .addInstrumentationLibraryMetricsBuilder()
+        .addMetricsBuilder();
+
+    metricsDataBuilder.getResourceMetricsBuilder(1)
+        .getResourceBuilder()
+        .addAttributes(KeyValue.newBuilder()
+          .setKey(RESOURCE_ATTRIBUTE_ENV)
+          .setValue(AnyValue.newBuilder().setStringValue(RESOURCE_ATTRIBUTE_VALUE_DEVEL))
+          .build());
+
+    metricsDataBuilder.getResourceMetricsBuilder(1)
+      .getInstrumentationLibraryMetricsBuilder(0)
+      .getInstrumentationLibraryBuilder()
+      .setName(INSTRUMENTATION_LIBRARY_NAME)
+      .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+
+    gaugeMetricBuilder.setName("example_gauge")
+      .getGaugeBuilder()
+      .addDataPointsBuilder()
+      .setAsInt(8)
+      .setTimeUnixNano(TIMESTAMP)
+      .addAttributesBuilder() // test sum with attributes
+      .setKey(METRIC_ATTRIBUTE_FOO_KEY)
+      .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_FOO_VAL).build());
+
+    MetricsData metricsData = metricsDataBuilder.build();
+    ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,
+        -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
+    KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        null,
+         "descriptor.",
+        "custom.");
+
+    CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
+        new TimestampSpec("timestamp", "iso", null),
+        dimensionsSpec,
+        Collections.emptyList()
+    ), kafkaRecordEntity, null).read();
+
+
+    Assert.assertTrue(rows.hasNext());
+    InputRow row = rows.next();
+
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_sum");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+    assertDimensionEquals(row, "value", "6");
+
+    Assert.assertTrue(rows.hasNext());
+    row = rows.next();
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_gauge");
+    assertDimensionEquals(row, "custom.env", "devel");
+    assertDimensionEquals(row, "descriptor.foo_key", "foo_value");
+    assertDimensionEquals(row, "value", "8");
+
+  }
+
+  @Test
+  public void testDimensionSpecExclusions() throws IOException
+  {
+    metricsDataBuilder.getResourceMetricsBuilder(0)
+      .getResourceBuilder()
+      .addAttributesBuilder()
+      .setKey(RESOURCE_ATTRIBUTE_ENV)
+      .setValue(AnyValue.newBuilder().setStringValue(RESOURCE_ATTRIBUTE_VALUE_DEVEL).build());
+
+    metricBuilder.setName("example_gauge")
+        .getGaugeBuilder()
+        .addDataPointsBuilder()
+        .setAsInt(6)
+        .setTimeUnixNano(TIMESTAMP)
+        .addAllAttributes(ImmutableList.of(
+          KeyValue.newBuilder()
+            .setKey(METRIC_ATTRIBUTE_COLOR)
+            .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build()).build(),
+          KeyValue.newBuilder()
+            .setKey(METRIC_ATTRIBUTE_FOO_KEY)
+            .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_FOO_VAL).build()).build()));
+
+    DimensionsSpec dimensionsSpecWithExclusions = new DimensionsSpec(null,
+        ImmutableList.of(
+          "descriptor." + METRIC_ATTRIBUTE_COLOR,
+          "custom." + RESOURCE_ATTRIBUTE_COUNTRY
+        ), null);
+
+    MetricsData metricsData = metricsDataBuilder.build();
+    ConsumerRecord consumerRecord = new ConsumerRecord(TOPIC, PARTITION, OFFSET, TS, TSTYPE,
+        -1L, -1, -1, null, metricsData.toByteArray(), HEADERS);
+    KafkaRecordEntity kafkaRecordEntity = new KafkaRecordEntity(consumerRecord);
+    OpenCensusProtobufInputFormat inputFormat = new OpenCensusProtobufInputFormat("metric.name",
+        null,
+        "descriptor.",
+        "custom.");
+
+    CloseableIterator<InputRow> rows = inputFormat.createReader(new InputRowSchema(
+        new TimestampSpec("timestamp", "iso", null),
+        dimensionsSpecWithExclusions,
+        Collections.emptyList()
+    ), kafkaRecordEntity, null).read();
+
+
+    Assert.assertTrue(rows.hasNext());
+    InputRow row = rows.next();
+
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_gauge");
+    assertDimensionEquals(row, "value", "6");
+    assertDimensionEquals(row, "custom.env", "devel");
+    assertDimensionEquals(row, "descriptor.foo_key", "foo_value");
+    Assert.assertFalse(row.getDimensions().contains("custom.country"));
+    Assert.assertFalse(row.getDimensions().contains("descriptor.color"));
+  }
+
+  private void assertDimensionEquals(InputRow row, String dimension, Object expected)
+  {
+    List<String> values = row.getDimension(dimension);
+    Assert.assertEquals(1, values.size());
+    Assert.assertEquals(expected, values.get(0));
+  }
+
+}

--- a/extensions-contrib/opencensus-extensions/src/test/resources/log4j2.xml
+++ b/extensions-contrib/opencensus-extensions/src/test/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<Configuration status="INFO">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+    <Logger level="info" name="org.apache.druid" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
+  </Loggers>
+</Configuration>

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -162,7 +162,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
         <executions>
           <execution>
             <id>opentelemetry-extension</id>

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -162,6 +162,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <id>opentelemetry-extension</id>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -53,6 +53,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>24.0.1</version>
+        <version>24.0.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.22.1</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>0.21.0</version>
+        <version>0.22.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>24.0.2</version>
+        <version>25.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -27,10 +27,6 @@
     <name>druid-opentelemetry-extensions</name>
     <description>druid-opentelemetry-extensions</description>
 
-    <properties>
-        <opentelemetry.proto.version>0.11.0-alpha</opentelemetry.proto.version>
-    </properties>
-
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
@@ -45,7 +41,6 @@
         <dependency>
             <groupId>io.opentelemetry.proto</groupId>
             <artifactId>opentelemetry-proto</artifactId>
-            <version>${opentelemetry.proto.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -73,6 +73,12 @@
             <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.druid</groupId>
+            <artifactId>druid-indexing-service</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- test -->
         <dependency>
             <groupId>junit</groupId>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>24.0.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <artifactId>druid</artifactId>
         <groupId>org.apache.druid</groupId>
-        <version>24.0.0</version>
+        <version>24.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>

--- a/extensions-contrib/opentelemetry-extensions/pom.xml
+++ b/extensions-contrib/opentelemetry-extensions/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.druid.extensions.contrib</groupId>
+    <artifactId>druid-opentelemetry-extensions</artifactId>
+    <name>druid-opentelemetry-extensions</name>
+    <description>druid-opentelemetry-extensions</description>
+
+    <properties>
+        <opentelemetry.proto.version>0.11.0-alpha</opentelemetry.proto.version>
+    </properties>
+
+    <parent>
+        <artifactId>druid</artifactId>
+        <groupId>org.apache.druid</groupId>
+        <version>0.21.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+            <version>${opentelemetry.proto.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.druid</groupId>
+            <artifactId>druid-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- jmh -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.27</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.27</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufInputFormat.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opentelemetry.protobuf;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.data.input.InputEntity;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.java.util.common.StringUtils;
+
+import java.io.File;
+import java.util.Objects;
+
+public class OpenTelemetryMetricsProtobufInputFormat implements InputFormat
+{
+  private static final String DEFAULT_METRIC_DIMENSION = "metric";
+  private static final String DEFAULT_VALUE_DIMENSION = "value";
+  private static final String DEFAULT_RESOURCE_PREFIX = "resource.";
+
+  private final String metricDimension;
+  private final String valueDimension;
+  private final String metricAttributePrefix;
+  private final String resourceAttributePrefix;
+
+  public OpenTelemetryMetricsProtobufInputFormat(
+      @JsonProperty("metricDimension") String metricDimension,
+      @JsonProperty("valueDimension") String valueDimension,
+      @JsonProperty("metricAttributePrefix") String metricAttributePrefix,
+      @JsonProperty("resourceAttributePrefix") String resourceAttributePrefix
+  )
+  {
+    this.metricDimension = metricDimension != null ? metricDimension : DEFAULT_METRIC_DIMENSION;
+    this.valueDimension = valueDimension != null ? valueDimension : DEFAULT_VALUE_DIMENSION;
+    this.metricAttributePrefix = StringUtils.nullToEmptyNonDruidDataString(metricAttributePrefix);
+    this.resourceAttributePrefix = resourceAttributePrefix != null ? resourceAttributePrefix : DEFAULT_RESOURCE_PREFIX;
+  }
+
+  @Override
+  public boolean isSplittable()
+  {
+    return false;
+  }
+
+  @Override
+  public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+  {
+    return new OpenTelemetryMetricsProtobufReader(
+            inputRowSchema.getDimensionsSpec(),
+            (ByteEntity) source,
+            metricDimension,
+            valueDimension,
+            metricAttributePrefix,
+            resourceAttributePrefix
+    );
+  }
+
+  @JsonProperty
+  public String getMetricDimension()
+  {
+    return metricDimension;
+  }
+
+  @JsonProperty
+  public String getValueDimension()
+  {
+    return valueDimension;
+  }
+
+  @JsonProperty
+  public String getMetricAttributePrefix()
+  {
+    return metricAttributePrefix;
+  }
+
+  @JsonProperty
+  public String getResourceAttributePrefix()
+  {
+    return resourceAttributePrefix;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof OpenTelemetryMetricsProtobufInputFormat)) {
+      return false;
+    }
+    OpenTelemetryMetricsProtobufInputFormat that = (OpenTelemetryMetricsProtobufInputFormat) o;
+    return Objects.equals(metricDimension, that.metricDimension)
+            && Objects.equals(valueDimension, that.valueDimension)
+            && Objects.equals(metricAttributePrefix, that.metricAttributePrefix)
+            && Objects.equals(resourceAttributePrefix, that.resourceAttributePrefix);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(metricDimension, valueDimension, metricAttributePrefix, resourceAttributePrefix);
+  }
+}

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -83,11 +83,13 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
     Supplier<Iterator<InputRow>> supplier = Suppliers.memoize(() -> readAsList().iterator());
     return CloseableIterators.withEmptyBaggage(new Iterator<InputRow>() {
       @Override
-      public boolean hasNext() {
+      public boolean hasNext()
+      {
         return supplier.get().hasNext();
       }
       @Override
-      public InputRow next() {
+      public InputRow next()
+      {
         return supplier.get().next();
       }
     });

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -36,8 +36,10 @@ import org.apache.druid.java.util.common.CloseableIterators;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -94,8 +96,14 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
           Map<String, Object> resourceAttributes = resourceMetrics.getResource()
               .getAttributesList()
               .stream()
-              .collect(Collectors.toMap(kv -> resourceAttributePrefix + kv.getKey(),
-                  kv -> parseAnyValue(kv.getValue())));
+              .collect(HashMap::new,
+                  (m, kv) -> {
+                    Object value = parseAnyValue(kv.getValue());
+                    if (value != null) {
+                      m.put(resourceAttributePrefix + kv.getKey(), value);
+                    }
+                  },
+                  HashMap::putAll);
           return resourceMetrics.getInstrumentationLibraryMetricsList()
               .stream()
               .flatMap(libraryMetrics -> libraryMetrics.getMetricsList()
@@ -142,8 +150,8 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
   {
 
     int capacity = resourceAttributes.size()
-            + dataPoint.getAttributesCount()
-            + 2; // metric name + value columns
+          + dataPoint.getAttributesCount()
+          + 2; // metric name + value columns
     Map<String, Object> event = Maps.newHashMapWithExpectedSize(capacity);
     event.put(metricDimension, metricName);
 
@@ -154,12 +162,17 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
     }
 
     event.putAll(resourceAttributes);
-    dataPoint.getAttributesList().forEach(att -> event.put(metricAttributePrefix + att.getKey(),
-        parseAnyValue(att.getValue())));
+    dataPoint.getAttributesList().forEach(att -> {
+      Object value = parseAnyValue(att.getValue());
+      if (value != null) {
+        event.put(metricAttributePrefix + att.getKey(), value);
+      }
+    });
 
     return createRow(TimeUnit.NANOSECONDS.toMillis(dataPoint.getTimeUnixNano()), event);
   }
 
+  @Nullable
   private static Object parseAnyValue(AnyValue value)
   {
     switch (value.getValueCase()) {
@@ -167,19 +180,16 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
         return value.getIntValue();
       case BOOL_VALUE:
         return value.getBoolValue();
-      case ARRAY_VALUE:
-        return value.getArrayValue();
-      case BYTES_VALUE:
-        return value.getBytesValue();
       case DOUBLE_VALUE:
         return value.getDoubleValue();
-      case KVLIST_VALUE:
-        return value.getKvlistValue();
       case STRING_VALUE:
         return value.getStringValue();
+
+      // TODO: Support KVLIST_VALUE, ARRAY_VALUE and BYTES_VALUE
+
       default:
-        // VALUE_NOT_SET:
-        return "";
+        // VALUE_NOT_SET
+        return null;
     }
   }
 

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -153,7 +153,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       case HISTOGRAM:
       case SUMMARY:
       default:
-        log.warn("Metric type " + metric.getDataCase() + " is not supported or deprecated.");
+        log.trace("Metric type " + metric.getDataCase() + " is not supported or deprecated.");
         inputRows = Collections.emptyList();
 
     }

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -35,6 +35,7 @@ import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.java.util.common.CloseableIterators;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
@@ -50,6 +51,8 @@ import java.util.stream.Collectors;
 
 public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
 {
+  private static final Logger log = new Logger(OpenTelemetryMetricsProtobufReader.class);
+
   private final ByteEntity source;
   private final String metricDimension;
   private final String valueDimension;
@@ -146,12 +149,11 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       }
       // TODO Support HISTOGRAM and SUMMARY metrics
       case HISTOGRAM:
-      case SUMMARY: {
-        inputRows = Collections.emptyList();
-        break;
-      }
+      case SUMMARY:
       default:
-        throw new IllegalStateException("Unexpected value: " + metric.getDataCase());
+        log.warn("Metric type " + metric.getDataCase() + " is not supported or deprecated.");
+        inputRows = Collections.emptyList();
+
     }
     return inputRows;
   }

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opentelemetry.protobuf;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowListPlusRawValues;
+import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.java.util.common.CloseableIterators;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.ParseException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
+{
+
+  private final ByteEntity source;
+  private final String metricDimension;
+  private final String valueDimension;
+  private final String metricAttributePrefix;
+  private final String resourceAttributePrefix;
+  private final DimensionsSpec dimensionsSpec;
+
+  public OpenTelemetryMetricsProtobufReader(
+      DimensionsSpec dimensionsSpec,
+      ByteEntity source,
+      String metricDimension,
+      String valueDimension,
+      String metricAttributePrefix,
+      String resourceAttributePrefix
+  )
+  {
+    this.dimensionsSpec = dimensionsSpec;
+    this.source = source;
+    this.metricDimension = metricDimension;
+    this.valueDimension = valueDimension;
+    this.metricAttributePrefix = metricAttributePrefix;
+    this.resourceAttributePrefix = resourceAttributePrefix;
+  }
+
+  @Override
+  public CloseableIterator<InputRow> read()
+  {
+    return CloseableIterators.withEmptyBaggage(readAsList().iterator());
+  }
+
+  List<InputRow> readAsList()
+  {
+    try {
+      return parseMetricsData(MetricsData.parseFrom(source.getBuffer()));
+    }
+    catch (InvalidProtocolBufferException e) {
+      throw new ParseException(e, "Protobuf message could not be parsed");
+    }
+  }
+
+  private List<InputRow> parseMetricsData(final MetricsData metricsData)
+  {
+    return metricsData.getResourceMetricsList()
+        .stream()
+        .flatMap(resourceMetrics -> {
+          Map<String, Object> resourceAttributes = resourceMetrics.getResource()
+              .getAttributesList()
+              .stream()
+              .collect(Collectors.toMap(kv -> resourceAttributePrefix + kv.getKey(),
+                  kv -> getStringValue(kv.getValue())));
+          return resourceMetrics.getInstrumentationLibraryMetricsList()
+              .stream()
+              .flatMap(libraryMetrics -> libraryMetrics.getMetricsList()
+                  .stream()
+                  .flatMap(metric -> parseMetric(metric, resourceAttributes).stream()));
+        })
+        .collect(Collectors.toList());
+  }
+
+  private List<InputRow> parseMetric(Metric metric, Map<String, Object> resourceAttributes)
+  {
+    final List<InputRow> inputRows;
+    String metricName = metric.getName();
+    switch (metric.getDataCase()) {
+      case SUM: {
+        inputRows = new ArrayList<>(metric.getSum().getDataPointsCount());
+        metric.getSum()
+            .getDataPointsList()
+            .forEach(dataPoint -> inputRows.add(parseNumberDataPoint(dataPoint, resourceAttributes, metricName)));
+        break;
+      }
+      case GAUGE: {
+        inputRows = new ArrayList<>(metric.getGauge().getDataPointsCount());
+        metric.getGauge()
+            .getDataPointsList()
+            .forEach(dataPoint -> inputRows.add(parseNumberDataPoint(dataPoint, resourceAttributes, metricName)));
+        break;
+      }
+      // TODO Support HISTOGRAM and SUMMARY metrics
+      default:
+        throw new IllegalStateException("Unexpected value: " + metric.getDataCase());
+    }
+    return inputRows;
+  }
+
+  private InputRow parseNumberDataPoint(NumberDataPoint dataPoint,
+                                        Map<String, Object> resourceAttributes,
+                                        String metricName)
+  {
+
+    int capacity = resourceAttributes.size()
+            + dataPoint.getAttributesCount()
+            + 2; // metric name + value columns
+    Map<String, Object> event = Maps.newHashMapWithExpectedSize(capacity);
+    event.put(metricDimension, metricName);
+
+    if (dataPoint.hasAsInt()) {
+      event.put(valueDimension, dataPoint.getAsInt());
+    } else if (dataPoint.hasAsDouble()) {
+      event.put(valueDimension, dataPoint.getAsDouble());
+    } else {
+      throw new IllegalStateException("Unexpected dataPoint value type. Expected Int or Double");
+    }
+
+    event.putAll(resourceAttributes);
+    dataPoint.getAttributesList().forEach(att -> event.put(metricAttributePrefix + att.getKey(),
+        getStringValue(att.getValue())));
+
+    return createRow(TimeUnit.NANOSECONDS.toMillis(dataPoint.getTimeUnixNano()), event);
+  }
+
+  private static String getStringValue(AnyValue value)
+  {
+    if (value.getValueCase() == AnyValue.ValueCase.STRING_VALUE) {
+      return value.getStringValue();
+    }
+    throw new IllegalStateException("Unexpected value: " + value.getValueCase());
+  }
+
+  InputRow createRow(long timeUnixMilli, Map<String, Object> event)
+  {
+    final List<String> dimensions;
+    if (!dimensionsSpec.getDimensionNames().isEmpty()) {
+      dimensions = dimensionsSpec.getDimensionNames();
+    } else {
+      dimensions = new ArrayList<>(Sets.difference(event.keySet(), dimensionsSpec.getDimensionExclusions()));
+    }
+    return new MapBasedInputRow(timeUnixMilli, dimensions, event);
+  }
+
+  @Override
+  public CloseableIterator<InputRowListPlusRawValues> sample()
+  {
+    return read().map(row -> InputRowListPlusRawValues.of(row, ((MapBasedInputRow) row).getEvent()));
+  }
+}

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -34,12 +34,14 @@ import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.CloseableIterators;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
 import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,7 +55,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
 {
   private static final Logger log = new Logger(OpenTelemetryMetricsProtobufReader.class);
 
-  private final ByteEntity source;
+  private final SettableByteEntity<? extends ByteEntity> source;
   private final String metricDimension;
   private final String valueDimension;
   private final String metricAttributePrefix;
@@ -62,7 +64,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
 
   public OpenTelemetryMetricsProtobufReader(
       DimensionsSpec dimensionsSpec,
-      ByteEntity source,
+      SettableByteEntity<? extends ByteEntity> source,
       String metricDimension,
       String valueDimension,
       String metricAttributePrefix,
@@ -98,7 +100,12 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
   List<InputRow> readAsList()
   {
     try {
-      return parseMetricsData(MetricsData.parseFrom(source.getBuffer()));
+      ByteBuffer buffer = source.getEntity().getBuffer();
+      List<InputRow> rows = parseMetricsData(MetricsData.parseFrom(buffer));
+      // Explicitly move the position assuming that all the remaining bytes have been consumed because the protobuf
+      // parser does not update the position itself
+      buffer.position(buffer.limit());
+      return rows;
     }
     catch (InvalidProtocolBufferException e) {
       throw new ParseException(null, e, "Protobuf message could not be parsed");
@@ -153,7 +160,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       case HISTOGRAM:
       case SUMMARY:
       default:
-        log.trace("Metric type {} is not supported", metric.getDataCase());
+        log.trace("Metric type %s is not supported", metric.getDataCase());
         inputRows = Collections.emptyList();
 
     }

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -84,7 +84,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       return parseMetricsData(MetricsData.parseFrom(source.getBuffer()));
     }
     catch (InvalidProtocolBufferException e) {
-      throw new ParseException(e, "Protobuf message could not be parsed");
+      throw new ParseException(null, e, "Protobuf message could not be parsed");
     }
   }
 

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -153,7 +153,7 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       case HISTOGRAM:
       case SUMMARY:
       default:
-        log.trace("Metric type " + metric.getDataCase() + " is not supported or deprecated.");
+        log.trace("Metric type {} is not supported", metric.getDataCase());
         inputRows = Collections.emptyList();
 
     }

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -128,9 +128,9 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
                     }
                   },
                   HashMap::putAll);
-          return resourceMetrics.getInstrumentationLibraryMetricsList()
+          return resourceMetrics.getScopeMetricsList()
               .stream()
-              .flatMap(libraryMetrics -> libraryMetrics.getMetricsList()
+              .flatMap(scopeMetrics -> scopeMetrics.getMetricsList()
                   .stream()
                   .flatMap(metric -> parseMetric(metric, resourceAttributes).stream()));
         })

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryProtobufExtensionsModule.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryProtobufExtensionsModule.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opentelemetry.protobuf;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.inject.Binder;
+import org.apache.druid.initialization.DruidModule;
+
+import java.util.Collections;
+import java.util.List;
+
+public class OpenTelemetryProtobufExtensionsModule implements DruidModule
+{
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return Collections.singletonList(
+        new SimpleModule("OpenTelemetryProtobufInputFormat")
+            .registerSubtypes(
+                new NamedType(OpenTelemetryMetricsProtobufInputFormat.class, "opentelemetry-metrics-protobuf")
+            )
+    );
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+  }
+}

--- a/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.data.input.opencensus.protobuf.OpenCensusProtobufExtensionsModule

--- a/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.druid.data.input.opencensus.protobuf.OpenCensusProtobufExtensionsModule
+org.apache.druid.data.input.opentelemetry.protobuf.OpenTelemetryMetricsProtobufInputFormat

--- a/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/opentelemetry-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.druid.data.input.opentelemetry.protobuf.OpenTelemetryMetricsProtobufInputFormat
+org.apache.druid.data.input.opentelemetry.protobuf.OpenTelemetryProtobufExtensionsModule
+

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
@@ -72,8 +72,7 @@ public class OpenTelemetryBenchmark
       new DimensionsSpec(ImmutableList.of(
           new StringDimensionSchema("name"),
           new StringDimensionSchema("value"),
-          new StringDimensionSchema("foo_key")),
-          null, null),
+          new StringDimensionSchema("foo_key"))),
       null);
 
   private static final OpenTelemetryMetricsProtobufInputFormat INPUT_FORMAT =

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
@@ -22,11 +22,11 @@ package org.apache.druid.data.input.opentelemetry.protobuf;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
-import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.MetricsData;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
 import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.metrics.v1.ScopeMetrics;
 import io.opentelemetry.proto.resource.v1.Resource;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
@@ -58,7 +58,7 @@ public class OpenTelemetryBenchmark
   private int resourceMetricCount = 1;
 
   @Param(value = {"1"})
-  private int instrumentationLibraryCount = 1;
+  private int instrumentationScopeCount = 1;
 
   @Param(value = {"1", "2", "4", "8" })
   private int metricsCount = 1;
@@ -94,12 +94,12 @@ public class OpenTelemetryBenchmark
         resourceAttributeBuilder.setValue(AnyValue.newBuilder().setStringValue("resource.label_value"));
       }
 
-      for (int j = 0; j < instrumentationLibraryCount; j++) {
-        InstrumentationLibraryMetrics.Builder instrumentationLibraryMetricsBuilder =
-            resourceMetricsBuilder.addInstrumentationLibraryMetricsBuilder();
+      for (int j = 0; j < instrumentationScopeCount; j++) {
+        ScopeMetrics.Builder scopeMetricsBuilder =
+            resourceMetricsBuilder.addScopeMetricsBuilder();
 
         for (int k = 0; k < metricsCount; k++) {
-          Metric.Builder metricBuilder = instrumentationLibraryMetricsBuilder.addMetricsBuilder();
+          Metric.Builder metricBuilder = scopeMetricsBuilder.addMetricsBuilder();
           metricBuilder.setName("io.confluent.domain/such/good/metric/wow");
 
           for (int l = 0; l < dataPointCount; l++) {

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryBenchmark.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opentelemetry.protobuf;
+
+import com.google.common.collect.ImmutableList;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.InstrumentationLibraryMetrics;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import io.opentelemetry.proto.metrics.v1.ResourceMetrics;
+import io.opentelemetry.proto.resource.v1.Resource;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@State(Scope.Benchmark)
+public class OpenTelemetryBenchmark
+{
+
+  private static ByteBuffer BUFFER;
+
+  @Param(value = {"1", "2", "4", "8" })
+  private int resourceMetricCount = 1;
+
+  @Param(value = {"1"})
+  private int instrumentationLibraryCount = 1;
+
+  @Param(value = {"1", "2", "4", "8" })
+  private int metricsCount = 1;
+
+  @Param(value = {"1", "2", "4", "8" })
+  private int dataPointCount;
+
+  private static final long TIMESTAMP = TimeUnit.MILLISECONDS.toNanos(Instant.parse("2019-07-12T09:30:01.123Z").toEpochMilli());
+
+  private static final InputRowSchema ROW_SCHEMA = new InputRowSchema(null,
+      new DimensionsSpec(ImmutableList.of(
+          new StringDimensionSchema("name"),
+          new StringDimensionSchema("value"),
+          new StringDimensionSchema("foo_key")),
+          null, null),
+      null);
+
+  private static final OpenTelemetryMetricsProtobufInputFormat INPUT_FORMAT =
+      new OpenTelemetryMetricsProtobufInputFormat("name",
+          "value",
+          "",
+          "resource.");
+
+  private ByteBuffer createMetricBuffer()
+  {
+    MetricsData.Builder metricsData = MetricsData.newBuilder();
+    for (int i = 0; i < resourceMetricCount; i++) {
+      ResourceMetrics.Builder resourceMetricsBuilder = metricsData.addResourceMetricsBuilder();
+      Resource.Builder resourceBuilder = resourceMetricsBuilder.getResourceBuilder();
+
+      for (int resourceAttributeI = 0; resourceAttributeI < 5; resourceAttributeI++) {
+        KeyValue.Builder resourceAttributeBuilder = resourceBuilder.addAttributesBuilder();
+        resourceAttributeBuilder.setKey("resource.label_key_" + resourceAttributeI);
+        resourceAttributeBuilder.setValue(AnyValue.newBuilder().setStringValue("resource.label_value"));
+      }
+
+      for (int j = 0; j < instrumentationLibraryCount; j++) {
+        InstrumentationLibraryMetrics.Builder instrumentationLibraryMetricsBuilder =
+            resourceMetricsBuilder.addInstrumentationLibraryMetricsBuilder();
+
+        for (int k = 0; k < metricsCount; k++) {
+          Metric.Builder metricBuilder = instrumentationLibraryMetricsBuilder.addMetricsBuilder();
+          metricBuilder.setName("io.confluent.domain/such/good/metric/wow");
+
+          for (int l = 0; l < dataPointCount; l++) {
+            NumberDataPoint.Builder dataPointBuilder = metricBuilder.getSumBuilder().addDataPointsBuilder();
+            dataPointBuilder.setAsDouble(42.0).setTimeUnixNano(TIMESTAMP);
+
+            for (int metricAttributeI = 0; metricAttributeI < 10; metricAttributeI++) {
+              KeyValue.Builder attributeBuilder = dataPointBuilder.addAttributesBuilder();
+              attributeBuilder.setKey("foo_key_" + metricAttributeI);
+              attributeBuilder.setValue(AnyValue.newBuilder().setStringValue("foo-value"));
+            }
+          }
+        }
+      }
+    }
+    return ByteBuffer.wrap(metricsData.build().toByteArray());
+  }
+
+  @Setup
+  public void init()
+  {
+    BUFFER = createMetricBuffer();
+  }
+
+  @Benchmark()
+  public void measureSerde(Blackhole blackhole) throws IOException
+  {
+    for (CloseableIterator<InputRow> it = INPUT_FORMAT.createReader(ROW_SCHEMA, new ByteEntity(BUFFER), null).read(); it.hasNext(); ) {
+      InputRow row = it.next();
+      blackhole.consume(row);
+    }
+  }
+}

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsInputFormatTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsInputFormatTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opentelemetry.protobuf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.InputFormat;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OpenTelemetryMetricsInputFormatTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    OpenTelemetryMetricsProtobufInputFormat inputFormat = new OpenTelemetryMetricsProtobufInputFormat(
+            "metric.name",
+            "raw.value",
+            "descriptor.",
+            "custom."
+    );
+
+    final ObjectMapper jsonMapper = new ObjectMapper();
+    jsonMapper.registerModules(new OpenTelemetryProtobufExtensionsModule().getJacksonModules());
+
+    final OpenTelemetryMetricsProtobufInputFormat actual = (OpenTelemetryMetricsProtobufInputFormat) jsonMapper.readValue(
+            jsonMapper.writeValueAsString(inputFormat),
+            InputFormat.class
+    );
+    Assert.assertEquals(inputFormat, actual);
+    Assert.assertEquals("metric.name", actual.getMetricDimension());
+    Assert.assertEquals("raw.value", actual.getValueDimension());
+    Assert.assertEquals("descriptor.", actual.getMetricAttributePrefix());
+    Assert.assertEquals("custom.", actual.getResourceAttributePrefix());
+  }
+
+  @Test
+  public void testDefaults()
+  {
+    OpenTelemetryMetricsProtobufInputFormat inputFormat = new OpenTelemetryMetricsProtobufInputFormat(
+            null,
+            null,
+            null,
+            null
+    );
+
+    Assert.assertEquals("metric", inputFormat.getMetricDimension());
+    Assert.assertEquals("value", inputFormat.getValueDimension());
+    Assert.assertEquals("", inputFormat.getMetricAttributePrefix());
+    Assert.assertEquals("resource.", inputFormat.getResourceAttributePrefix());
+  }
+}

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -53,8 +53,8 @@ public class OpenTelemetryMetricsProtobufReaderTest
   public static final String RESOURCE_ATTRIBUTE_ENV = "env";
   public static final String RESOURCE_ATTRIBUTE_VALUE_DEVEL = "devel";
 
-  public static final String INSTRUMENTATION_LIBRARY_NAME = "mock-instr-lib";
-  public static final String INSTRUMENTATION_LIBRARY_VERSION = "1.0";
+  public static final String INSTRUMENTATION_SCOPE_NAME = "mock-instr-lib";
+  public static final String INSTRUMENTATION_SCOPE_VERSION = "1.0";
 
   public static final String METRIC_ATTRIBUTE_COLOR = "color";
   public static final String METRIC_ATTRIBUTE_VALUE_RED = "red";
@@ -65,7 +65,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
   private final MetricsData.Builder metricsDataBuilder = MetricsData.newBuilder();
 
   private final Metric.Builder metricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
-      .addInstrumentationLibraryMetricsBuilder()
+      .addScopeMetricsBuilder()
       .addMetricsBuilder();
 
   private final DimensionsSpec dimensionsSpec = new DimensionsSpec(ImmutableList.of(
@@ -90,10 +90,10 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     metricsDataBuilder
         .getResourceMetricsBuilder(0)
-        .getInstrumentationLibraryMetricsBuilder(0)
-        .getInstrumentationLibraryBuilder()
-        .setName(INSTRUMENTATION_LIBRARY_NAME)
-        .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+        .getScopeMetricsBuilder(0)
+        .getScopeBuilder()
+        .setName(INSTRUMENTATION_SCOPE_NAME)
+        .setVersion(INSTRUMENTATION_SCOPE_VERSION);
 
   }
 
@@ -184,7 +184,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     // Create Second Metric
     Metric.Builder gaugeMetricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
-        .addInstrumentationLibraryMetricsBuilder()
+        .addScopeMetricsBuilder()
         .addMetricsBuilder();
 
     metricsDataBuilder.getResourceMetricsBuilder(1)
@@ -195,10 +195,10 @@ public class OpenTelemetryMetricsProtobufReaderTest
             .build());
 
     metricsDataBuilder.getResourceMetricsBuilder(1)
-        .getInstrumentationLibraryMetricsBuilder(0)
-        .getInstrumentationLibraryBuilder()
-        .setName(INSTRUMENTATION_LIBRARY_NAME)
-        .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+        .getScopeMetricsBuilder(0)
+        .getScopeBuilder()
+        .setName(INSTRUMENTATION_SCOPE_NAME)
+        .setVersion(INSTRUMENTATION_SCOPE_VERSION);
 
     gaugeMetricBuilder.setName("example_gauge")
         .getGaugeBuilder()
@@ -381,8 +381,8 @@ public class OpenTelemetryMetricsProtobufReaderTest
   public void testInvalidMetricType()
   {
     metricBuilder
-        .setName("deprecated_intsum")
-        .getIntSumBuilder()
+        .setName("unsupported_histogram_metric")
+        .getExponentialHistogramBuilder()
         .addDataPointsBuilder()
         .setTimeUnixNano(TIMESTAMP);
 

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -344,8 +344,9 @@ public class OpenTelemetryMetricsProtobufReaderTest
   }
 
   @Test
-  public void testInvalidProtobuf() {
-    byte[] invalidProtobuf = new byte[] { 0x00, 0x01 };
+  public void testInvalidProtobuf()
+  {
+    byte[] invalidProtobuf = new byte[] {0x00, 0x01};
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
         new ByteEntity(invalidProtobuf),
@@ -359,7 +360,8 @@ public class OpenTelemetryMetricsProtobufReaderTest
   }
   
   @Test
-  public void testInvalidMetricType() {
+  public void testInvalidMetricType()
+  {
     metricBuilder
         .setName("deprecated_intsum")
         .getIntSumBuilder()

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -357,6 +357,30 @@ public class OpenTelemetryMetricsProtobufReaderTest
     Assert.assertThrows(ParseException.class, () -> rows.hasNext());
     Assert.assertThrows(ParseException.class, () -> rows.next());
   }
+  
+  @Test
+  public void testInvalidMetricType() {
+    metricBuilder
+        .setName("deprecated_intsum")
+        .getIntSumBuilder()
+        .addDataPointsBuilder()
+        .setTimeUnixNano(TIMESTAMP);
+
+    MetricsData metricsData = metricsDataBuilder.build();
+
+    CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
+        dimensionsSpec,
+        new ByteEntity(metricsData.toByteArray()),
+        "metric.name",
+        "raw.value",
+        "descriptor.",
+        "custom."
+    ).read();
+
+    List<InputRow> rowList = new ArrayList<>();
+    rows.forEachRemaining(rowList::add);
+    Assert.assertEquals(0, rowList.size());
+  }
 
   private void assertDimensionEquals(InputRow row, String dimension, Object expected)
   {

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.junit.Assert;
@@ -37,6 +38,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -110,9 +112,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -145,9 +149,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -205,9 +211,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -262,9 +270,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
             "custom." + RESOURCE_ATTRIBUTE_COUNTRY
     )).build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpecWithExclusions,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -315,9 +325,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
@@ -347,18 +359,24 @@ public class OpenTelemetryMetricsProtobufReaderTest
   public void testInvalidProtobuf()
   {
     byte[] invalidProtobuf = new byte[] {0x00, 0x01};
-    CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(invalidProtobuf));
+    try (CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(invalidProtobuf),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",
         "custom."
-    ).read();
-    Assert.assertThrows(ParseException.class, () -> rows.hasNext());
-    Assert.assertThrows(ParseException.class, () -> rows.next());
+    ).read()) {
+      Assert.assertThrows(ParseException.class, () -> rows.hasNext());
+      Assert.assertThrows(ParseException.class, () -> rows.next());
+    }
+    catch (IOException e) {
+      // Comes from the implicit call to close. Ignore
+    }
   }
-  
+
   @Test
   public void testInvalidMetricType()
   {
@@ -370,9 +388,11 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
+    SettableByteEntity<ByteEntity> settableByteEntity = new SettableByteEntity<>();
+    settableByteEntity.setEntity(new ByteEntity(metricsData.toByteArray()));
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpec,
-        new ByteEntity(metricsData.toByteArray()),
+        settableByteEntity,
         "metric.name",
         "raw.value",
         "descriptor.",

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -70,7 +70,7 @@ public class OpenTelemetryMetricsProtobufReaderTest
       new StringDimensionSchema("descriptor." + METRIC_ATTRIBUTE_FOO_KEY),
       new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_ENV),
       new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_COUNTRY)
-  ), null, null);
+  ));
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -256,11 +256,10 @@ public class OpenTelemetryMetricsProtobufReaderTest
 
     MetricsData metricsData = metricsDataBuilder.build();
 
-    DimensionsSpec dimensionsSpecWithExclusions = new DimensionsSpec(null,
-        ImmutableList.of(
+    DimensionsSpec dimensionsSpecWithExclusions = DimensionsSpec.builder().setDimensionExclusions(ImmutableList.of(
             "descriptor." + METRIC_ATTRIBUTE_COLOR,
             "custom." + RESOURCE_ATTRIBUTE_COUNTRY
-        ), null);
+    )).build();
 
     CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
         dimensionsSpecWithExclusions,

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.ParseException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -340,6 +341,21 @@ public class OpenTelemetryMetricsProtobufReaderTest
     Assert.assertEquals(0, row.getDimension("descriptor.foo_key").size());
 
     assertDimensionEquals(row, "raw.value", "6");
+  }
+
+  @Test
+  public void testInvalidProtobuf() {
+    byte[] invalidProtobuf = new byte[] { 0x00, 0x01 };
+    CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
+        dimensionsSpec,
+        new ByteEntity(invalidProtobuf),
+        "metric.name",
+        "raw.value",
+        "descriptor.",
+        "custom."
+    ).read();
+    Assert.assertThrows(ParseException.class, () -> rows.hasNext());
+    Assert.assertThrows(ParseException.class, () -> rows.next());
   }
 
   private void assertDimensionEquals(InputRow row, String dimension, Object expected)

--- a/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
+++ b/extensions-contrib/opentelemetry-extensions/src/test/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReaderTest.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.opentelemetry.protobuf;
+
+import com.google.common.collect.ImmutableList;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.Metric;
+import io.opentelemetry.proto.metrics.v1.MetricsData;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class OpenTelemetryMetricsProtobufReaderTest
+{
+  private static final long TIMESTAMP = TimeUnit.MILLISECONDS.toNanos(Instant.parse("2019-07-12T09:30:01.123Z").toEpochMilli());
+  public static final String RESOURCE_ATTRIBUTE_COUNTRY = "country";
+  public static final String RESOURCE_ATTRIBUTE_VALUE_USA = "usa";
+
+  public static final String RESOURCE_ATTRIBUTE_ENV = "env";
+  public static final String RESOURCE_ATTRIBUTE_VALUE_DEVEL = "devel";
+
+  public static final String INSTRUMENTATION_LIBRARY_NAME = "mock-instr-lib";
+  public static final String INSTRUMENTATION_LIBRARY_VERSION = "1.0";
+
+  public static final String METRIC_ATTRIBUTE_COLOR = "color";
+  public static final String METRIC_ATTRIBUTE_VALUE_RED = "red";
+
+  public static final String METRIC_ATTRIBUTE_FOO_KEY = "foo_key";
+  public static final String METRIC_ATTRIBUTE_FOO_VAL = "foo_value";
+
+  private final MetricsData.Builder metricsDataBuilder = MetricsData.newBuilder();
+
+  private final Metric.Builder metricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
+      .addInstrumentationLibraryMetricsBuilder()
+      .addMetricsBuilder();
+
+  private final DimensionsSpec dimensionsSpec = new DimensionsSpec(ImmutableList.of(
+      new StringDimensionSchema("descriptor." + METRIC_ATTRIBUTE_COLOR),
+      new StringDimensionSchema("descriptor." + METRIC_ATTRIBUTE_FOO_KEY),
+      new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_ENV),
+      new StringDimensionSchema("custom." + RESOURCE_ATTRIBUTE_COUNTRY)
+  ), null, null);
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setUp()
+  {
+    metricsDataBuilder
+        .getResourceMetricsBuilder(0)
+        .getResourceBuilder()
+        .addAttributes(KeyValue.newBuilder()
+            .setKey(RESOURCE_ATTRIBUTE_COUNTRY)
+            .setValue(AnyValue.newBuilder().setStringValue(RESOURCE_ATTRIBUTE_VALUE_USA)));
+
+    metricsDataBuilder
+        .getResourceMetricsBuilder(0)
+        .getInstrumentationLibraryMetricsBuilder(0)
+        .getInstrumentationLibraryBuilder()
+        .setName(INSTRUMENTATION_LIBRARY_NAME)
+        .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+
+  }
+
+  @Test
+  public void testSumWithAttributes()
+  {
+    metricBuilder
+        .setName("example_sum")
+        .getSumBuilder()
+        .addDataPointsBuilder()
+        .setAsInt(6)
+        .setTimeUnixNano(TIMESTAMP)
+        .addAttributesBuilder() // test sum with attributes
+        .setKey(METRIC_ATTRIBUTE_COLOR)
+        .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
+
+    MetricsData metricsData = metricsDataBuilder.build();
+
+    CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
+        dimensionsSpec,
+        new ByteEntity(metricsData.toByteArray()),
+        "metric.name",
+        "raw.value",
+        "descriptor.",
+        "custom."
+    ).read();
+
+    List<InputRow> rowList = new ArrayList<>();
+    rows.forEachRemaining(rowList::add);
+    Assert.assertEquals(1, rowList.size());
+
+    InputRow row = rowList.get(0);
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_sum");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+    assertDimensionEquals(row, "raw.value", "6");
+  }
+
+  @Test
+  public void testGaugeWithAttributes()
+  {
+    metricBuilder.setName("example_gauge")
+        .getGaugeBuilder()
+        .addDataPointsBuilder()
+        .setAsInt(6)
+        .setTimeUnixNano(TIMESTAMP)
+        .addAttributesBuilder() // test sum with attributes
+        .setKey(METRIC_ATTRIBUTE_COLOR)
+        .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
+
+    MetricsData metricsData = metricsDataBuilder.build();
+
+    CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
+        dimensionsSpec,
+        new ByteEntity(metricsData.toByteArray()),
+        "metric.name",
+        "raw.value",
+        "descriptor.",
+        "custom."
+    ).read();
+
+    Assert.assertTrue(rows.hasNext());
+    InputRow row = rows.next();
+
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_gauge");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+    assertDimensionEquals(row, "raw.value", "6");
+  }
+
+  @Test
+  public void testBatchedMetricParse()
+  {
+    metricBuilder.setName("example_sum")
+        .getSumBuilder()
+        .addDataPointsBuilder()
+        .setAsInt(6)
+        .setTimeUnixNano(TIMESTAMP)
+        .addAttributesBuilder() // test sum with attributes
+        .setKey(METRIC_ATTRIBUTE_COLOR)
+        .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build());
+
+    // Create Second Metric
+    Metric.Builder gaugeMetricBuilder = metricsDataBuilder.addResourceMetricsBuilder()
+        .addInstrumentationLibraryMetricsBuilder()
+        .addMetricsBuilder();
+
+    metricsDataBuilder.getResourceMetricsBuilder(1)
+        .getResourceBuilder()
+        .addAttributes(KeyValue.newBuilder()
+            .setKey(RESOURCE_ATTRIBUTE_ENV)
+            .setValue(AnyValue.newBuilder().setStringValue(RESOURCE_ATTRIBUTE_VALUE_DEVEL))
+            .build());
+
+    metricsDataBuilder.getResourceMetricsBuilder(1)
+        .getInstrumentationLibraryMetricsBuilder(0)
+        .getInstrumentationLibraryBuilder()
+        .setName(INSTRUMENTATION_LIBRARY_NAME)
+        .setVersion(INSTRUMENTATION_LIBRARY_VERSION);
+
+    gaugeMetricBuilder.setName("example_gauge")
+        .getGaugeBuilder()
+        .addDataPointsBuilder()
+        .setAsInt(8)
+        .setTimeUnixNano(TIMESTAMP)
+        .addAttributesBuilder() // test sum with attributes
+        .setKey(METRIC_ATTRIBUTE_FOO_KEY)
+        .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_FOO_VAL).build());
+
+    MetricsData metricsData = metricsDataBuilder.build();
+
+    CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
+        dimensionsSpec,
+        new ByteEntity(metricsData.toByteArray()),
+        "metric.name",
+        "raw.value",
+        "descriptor.",
+        "custom."
+    ).read();
+
+    Assert.assertTrue(rows.hasNext());
+    InputRow row = rows.next();
+
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_sum");
+    assertDimensionEquals(row, "custom.country", "usa");
+    assertDimensionEquals(row, "descriptor.color", "red");
+    assertDimensionEquals(row, "raw.value", "6");
+
+    Assert.assertTrue(rows.hasNext());
+    row = rows.next();
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_gauge");
+    assertDimensionEquals(row, "custom.env", "devel");
+    assertDimensionEquals(row, "descriptor.foo_key", "foo_value");
+    assertDimensionEquals(row, "raw.value", "8");
+
+  }
+
+  @Test
+  public void testDimensionSpecExclusions()
+  {
+    metricsDataBuilder.getResourceMetricsBuilder(0)
+        .getResourceBuilder()
+        .addAttributesBuilder()
+        .setKey(RESOURCE_ATTRIBUTE_ENV)
+        .setValue(AnyValue.newBuilder().setStringValue(RESOURCE_ATTRIBUTE_VALUE_DEVEL).build());
+
+    metricBuilder.setName("example_gauge")
+        .getGaugeBuilder()
+        .addDataPointsBuilder()
+        .setAsInt(6)
+        .setTimeUnixNano(TIMESTAMP)
+        .addAllAttributes(ImmutableList.of(
+            KeyValue.newBuilder()
+                .setKey(METRIC_ATTRIBUTE_COLOR)
+                .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_VALUE_RED).build()).build(),
+            KeyValue.newBuilder()
+                .setKey(METRIC_ATTRIBUTE_FOO_KEY)
+                .setValue(AnyValue.newBuilder().setStringValue(METRIC_ATTRIBUTE_FOO_VAL).build()).build()));
+
+    MetricsData metricsData = metricsDataBuilder.build();
+
+    DimensionsSpec dimensionsSpecWithExclusions = new DimensionsSpec(null,
+        ImmutableList.of(
+            "descriptor." + METRIC_ATTRIBUTE_COLOR,
+            "custom." + RESOURCE_ATTRIBUTE_COUNTRY
+        ), null);
+
+    CloseableIterator<InputRow> rows = new OpenTelemetryMetricsProtobufReader(
+        dimensionsSpecWithExclusions,
+        new ByteEntity(metricsData.toByteArray()),
+        "metric.name",
+        "raw.value",
+        "descriptor.",
+        "custom."
+    ).read();
+
+    Assert.assertTrue(rows.hasNext());
+    InputRow row = rows.next();
+
+    Assert.assertEquals(4, row.getDimensions().size());
+    assertDimensionEquals(row, "metric.name", "example_gauge");
+    assertDimensionEquals(row, "raw.value", "6");
+    assertDimensionEquals(row, "custom.env", "devel");
+    assertDimensionEquals(row, "descriptor.foo_key", "foo_value");
+    Assert.assertFalse(row.getDimensions().contains("custom.country"));
+    Assert.assertFalse(row.getDimensions().contains("descriptor.color"));
+  }
+
+  private void assertDimensionEquals(InputRow row, String dimension, Object expected)
+  {
+    List<String> values = row.getDimension(dimension);
+    Assert.assertEquals(1, values.size());
+    Assert.assertEquals(expected, values.get(0));
+  }
+
+}

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3StorageConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3StorageConfig.java
@@ -36,17 +36,33 @@ public class S3StorageConfig
   @JsonProperty("sse")
   private final ServerSideEncryption serverSideEncryption;
 
+  /**
+   * S3 transfer config.
+   *
+   * @see S3StorageDruidModule#configure
+   */
+  @JsonProperty("transfer")
+  private final S3TransferConfig s3TransferConfig;
+
   @JsonCreator
   public S3StorageConfig(
-      @JsonProperty("sse") ServerSideEncryption serverSideEncryption
+      @JsonProperty("sse") ServerSideEncryption serverSideEncryption,
+      @JsonProperty("transfer") S3TransferConfig s3TransferConfig
   )
   {
     this.serverSideEncryption = serverSideEncryption == null ? new NoopServerSideEncryption() : serverSideEncryption;
+    this.s3TransferConfig = s3TransferConfig == null ? new S3TransferConfig() : s3TransferConfig;
   }
 
   @JsonProperty("sse")
   public ServerSideEncryption getServerSideEncryption()
   {
     return serverSideEncryption;
+  }
+
+  @JsonProperty("transfer")
+  public S3TransferConfig getS3TransferConfig()
+  {
+    return s3TransferConfig;
   }
 }

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TransferConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TransferConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.storage.s3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.Min;
+
+/**
+ */
+public class S3TransferConfig
+{
+  @JsonProperty
+  private boolean useTransferManager = false;
+
+  @JsonProperty
+  @Min(1)
+  private long minimumUploadPartSize = 5 * 1024 * 1024L;
+
+  @JsonProperty
+  @Min(1)
+  private long multipartUploadThreshold = 5 * 1024 * 1024L;
+
+  public void setUseTransferManager(boolean useTransferManager)
+  {
+    this.useTransferManager = useTransferManager;
+  }
+
+  public void setMinimumUploadPartSize(long minimumUploadPartSize)
+  {
+    this.minimumUploadPartSize = minimumUploadPartSize;
+  }
+
+  public void setMultipartUploadThreshold(long multipartUploadThreshold)
+  {
+    this.multipartUploadThreshold = multipartUploadThreshold;
+  }
+
+  public boolean isUseTransferManager()
+  {
+    return useTransferManager;
+  }
+
+  public long getMinimumUploadPartSize()
+  {
+    return minimumUploadPartSize;
+  }
+
+  public long getMultipartUploadThreshold()
+  {
+    return multipartUploadThreshold;
+  }
+
+}

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -81,6 +81,9 @@ public class S3Utils
         // SdkClientException can be thrown for many reasons and the only way to distinguish it is to look at
         // the message. This is not ideal, since the message may change, so it may need to be adjusted in the future.
         return true;
+      } else if (e instanceof InterruptedException) {
+        Thread.interrupted(); // Clear interrupted state and not retry
+        return false;
       } else if (e instanceof AmazonClientException) {
         return AWSClientUtil.isClientExceptionRecoverable((AmazonClientException) e);
       } else {
@@ -312,7 +315,7 @@ public class S3Utils
       String bucket,
       String key,
       File file
-  )
+  ) throws InterruptedException
   {
     final PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, key, file);
 
@@ -320,7 +323,7 @@ public class S3Utils
       putObjectRequest.setAccessControlList(S3Utils.grantFullControlToBucketOwner(service, bucket));
     }
     log.info("Pushing [%s] to bucket[%s] and key[%s].", file, bucket, key);
-    service.putObject(putObjectRequest);
+    service.upload(putObjectRequest);
   }
 
   @Nullable

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -68,6 +68,7 @@ import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.metadata.DefaultPasswordProvider;
 import org.apache.druid.storage.s3.NoopServerSideEncryption;
 import org.apache.druid.storage.s3.S3InputDataConfig;
+import org.apache.druid.storage.s3.S3TransferConfig;
 import org.apache.druid.storage.s3.S3Utils;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
 import org.apache.druid.testing.InitializedNullHandlingTest;
@@ -106,7 +107,8 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
   private static final AmazonS3ClientBuilder AMAZON_S3_CLIENT_BUILDER = AmazonS3Client.builder();
   private static final ServerSideEncryptingAmazonS3 SERVICE = new ServerSideEncryptingAmazonS3(
       S3_CLIENT,
-      new NoopServerSideEncryption()
+      new NoopServerSideEncryption(),
+      new S3TransferConfig()
   );
   private static final S3InputDataConfig INPUT_DATA_CONFIG;
   private static final int MAX_LISTING_LENGTH = 10;

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/firehose/s3/StaticS3FirehoseFactoryTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/firehose/s3/StaticS3FirehoseFactoryTest.java
@@ -25,6 +25,7 @@ import org.apache.druid.data.input.FiniteFirehoseFactory;
 import org.apache.druid.data.input.impl.StringInputRowParser;
 import org.apache.druid.data.input.s3.S3InputSourceTest;
 import org.apache.druid.storage.s3.NoopServerSideEncryption;
+import org.apache.druid.storage.s3.S3TransferConfig;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -44,7 +45,8 @@ public class StaticS3FirehoseFactoryTest
   private static final AmazonS3Client S3_CLIENT = EasyMock.createNiceMock(AmazonS3Client.class);
   private static final ServerSideEncryptingAmazonS3 SERVICE = new ServerSideEncryptingAmazonS3(
       S3_CLIENT,
-      new NoopServerSideEncryption()
+      new NoopServerSideEncryption(),
+      new S3TransferConfig()
   );
 
   @Test

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ObjectSummaryIteratorTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ObjectSummaryIteratorTest.java
@@ -195,7 +195,7 @@ public class ObjectSummaryIteratorTest
       final List<S3ObjectSummary> objects
   )
   {
-    return new ServerSideEncryptingAmazonS3(null, null)
+    return new ServerSideEncryptingAmazonS3(null, null, new S3TransferConfig())
     {
       @Override
       public ListObjectsV2Result listObjectsV2(final ListObjectsV2Request request)

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
@@ -76,7 +76,8 @@ public class S3DataSegmentArchiverTest
   private static final Supplier<ServerSideEncryptingAmazonS3> S3_SERVICE = Suppliers.ofInstance(
       new ServerSideEncryptingAmazonS3(
           EasyMock.createStrictMock(AmazonS3Client.class),
-          new NoopServerSideEncryption()
+          new NoopServerSideEncryption(),
+          new S3TransferConfig()
       )
   );
   private static final S3DataSegmentPuller PULLER = new S3DataSegmentPuller(S3_SERVICE.get());

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentMoverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentMoverTest.java
@@ -201,7 +201,7 @@ public class S3DataSegmentMoverTest
 
     private MockAmazonS3Client()
     {
-      super(new AmazonS3Client(), new NoopServerSideEncryption());
+      super(new AmazonS3Client(), new NoopServerSideEncryption(), new S3TransferConfig());
     }
 
     public boolean didMove()

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherTest.java
@@ -24,7 +24,7 @@ import com.amazonaws.services.s3.model.CanonicalGrantee;
 import com.amazonaws.services.s3.model.Grant;
 import com.amazonaws.services.s3.model.Owner;
 import com.amazonaws.services.s3.model.Permission;
-import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.google.common.io.Files;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
@@ -83,9 +83,8 @@ public class S3DataSegmentPusherTest
     acl.grantAllPermissions(new Grant(new CanonicalGrantee(acl.getOwner().getId()), Permission.FullControl));
     EasyMock.expect(s3Client.getBucketAcl(EasyMock.eq("bucket"))).andReturn(acl).once();
 
-    EasyMock.expect(s3Client.putObject(EasyMock.anyObject()))
-            .andReturn(new PutObjectResult())
-            .once();
+    s3Client.upload(EasyMock.anyObject(PutObjectRequest.class));
+    EasyMock.expectLastCall().once();
 
     EasyMock.replay(s3Client);
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageConnectorProviderTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageConnectorProviderTest.java
@@ -145,7 +145,7 @@ public class S3StorageConnectorProviderTest
         new InjectableValues.Std()
             .addValue(
                 ServerSideEncryptingAmazonS3.class,
-                new ServerSideEncryptingAmazonS3(null, new NoopServerSideEncryption())
+                new ServerSideEncryptingAmazonS3(null, new NoopServerSideEncryption(), new S3TransferConfig())
             ));
 
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
@@ -28,7 +28,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.Owner;
 import com.amazonaws.services.s3.model.Permission;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.base.Optional;
@@ -449,9 +448,8 @@ public class S3TaskLogsTest extends EasyMockSupport
 
   private List<Grant> testPushInternal(boolean disableAcl, String ownerId, String ownerDisplayName) throws Exception
   {
-    EasyMock.expect(s3Client.putObject(EasyMock.anyObject()))
-            .andReturn(new PutObjectResult())
-            .once();
+    s3Client.upload(EasyMock.anyObject(PutObjectRequest.class));
+    EasyMock.expectLastCall().once();
 
     AccessControlList aclExpected = new AccessControlList();
     aclExpected.setOwner(new Owner(ownerId, ownerDisplayName));
@@ -460,9 +458,8 @@ public class S3TaskLogsTest extends EasyMockSupport
             .andReturn(aclExpected)
             .once();
 
-    EasyMock.expect(s3Client.putObject(EasyMock.anyObject(PutObjectRequest.class)))
-            .andReturn(new PutObjectResult())
-            .once();
+    s3Client.upload(EasyMock.anyObject(PutObjectRequest.class));
+    EasyMock.expectLastCall().once();
 
     EasyMock.replay(s3Client);
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/TestAWSCredentialsProvider.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/TestAWSCredentialsProvider.java
@@ -67,7 +67,7 @@ public class TestAWSCredentialsProvider
         new AWSProxyConfig(),
         new AWSEndpointConfig(),
         new AWSClientConfig(),
-        new S3StorageConfig(new NoopServerSideEncryption())
+        new S3StorageConfig(new NoopServerSideEncryption(), null)
     );
 
     s3Module.getAmazonS3Client(
@@ -102,7 +102,7 @@ public class TestAWSCredentialsProvider
         new AWSProxyConfig(),
         new AWSEndpointConfig(),
         new AWSClientConfig(),
-        new S3StorageConfig(new NoopServerSideEncryption())
+        new S3StorageConfig(new NoopServerSideEncryption(), null)
     );
 
     s3Module.getAmazonS3Client(

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.storage.s3.NoopServerSideEncryption;
+import org.apache.druid.storage.s3.S3TransferConfig;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
 import org.easymock.EasyMock;
 import org.hamcrest.CoreMatchers;
@@ -272,7 +273,7 @@ public class RetryableS3OutputStreamTest
 
     private TestAmazonS3(int totalUploadFailures)
     {
-      super(EasyMock.createMock(AmazonS3.class), new NoopServerSideEncryption());
+      super(EasyMock.createMock(AmazonS3.class), new NoopServerSideEncryption(), new S3TransferConfig());
       this.uploadFailuresLeft = totalUploadFailures;
     }
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3StorageConnectorTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3StorageConnectorTest.java
@@ -29,6 +29,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.storage.StorageConnector;
 import org.apache.druid.storage.s3.NoopServerSideEncryption;
+import org.apache.druid.storage.s3.S3TransferConfig;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -52,7 +53,8 @@ public class S3StorageConnectorTest
   private static final AmazonS3Client S3_CLIENT = EasyMock.createMock(AmazonS3Client.class);
   private static final ServerSideEncryptingAmazonS3 SERVICE = new ServerSideEncryptingAmazonS3(
       S3_CLIENT,
-      new NoopServerSideEncryption()
+      new NoopServerSideEncryption(),
+      new S3TransferConfig()
   );
 
   private static final String BUCKET = "BUCKET";

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <repoOrgId>apache.snapshots</repoOrgId>
         <repoOrgName>Apache Snapshot Repository</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/snapshots</repoOrgUrl>
+        <opentelemetry.proto.version>0.11.0-alpha</opentelemetry.proto.version>
 
         <!-- Allow the handful of flaky tests with transient failures to pass. -->
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
@@ -1199,6 +1200,11 @@
               </exclusion>
             </exclusions>
           </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.proto</groupId>
+                <artifactId>opentelemetry-proto</artifactId>
+                <version>${opentelemetry.proto.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <repoOrgId>apache.snapshots</repoOrgId>
         <repoOrgName>Apache Snapshot Repository</repoOrgName>
         <repoOrgUrl>https://repository.apache.org/snapshots</repoOrgUrl>
-        <opentelemetry.proto.version>0.11.0-alpha</opentelemetry.proto.version>
+        <opentelemetry.proto.version>0.19.0-alpha</opentelemetry.proto.version>
 
         <!-- Allow the handful of flaky tests with transient failures to pass. -->
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@
         <module>extensions-contrib/opencensus-extensions</module>
         <module>extensions-contrib/confluent-extensions</module>
         <module>extensions-contrib/opentelemetry-emitter</module>
+        <module>extensions-contrib/opentelemetry-extensions</module>
         <!-- distribution packaging -->
         <module>distribution</module>
         <!-- Revised integration tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,6 @@
         <module>extensions-contrib/kubernetes-overlord-extensions</module>
         <module>extensions-contrib/opencensus-extensions</module>
         <module>extensions-contrib/confluent-extensions</module>
-        <module>extensions-contrib/opentelemetry-emitter</module>
         <module>extensions-contrib/opentelemetry-extensions</module>
         <!-- distribution packaging -->
         <module>distribution</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1520,7 +1520,7 @@
                                 <projectName>Apache Druid</projectName>
                             </properties>
                             <resourceBundles>
-                                <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT</resourceBundle>
+                                <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5</resourceBundle>
                             </resourceBundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -747,6 +747,11 @@
                 <version>${protobuf.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java-util</artifactId>
+                <version>${protobuf.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.tesla.aether</groupId>
                 <artifactId>tesla-aether</artifactId>
                 <version>0.0.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@
         <module>extensions-contrib/kubernetes-overlord-extensions</module>
         <module>extensions-contrib/opencensus-extensions</module>
         <module>extensions-contrib/confluent-extensions</module>
+        <module>extensions-contrib/opentelemetry-emitter</module>
         <!-- distribution packaging -->
         <module>distribution</module>
         <!-- Revised integration tests -->

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/IngestSegmentFirehoseTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.realtime.firehose;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.druid.collections.spatial.search.RadiusBound;
+import org.apache.druid.common.config.NullHandlingTest;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.DelimitedParseSpec;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -66,7 +67,7 @@ import java.util.List;
 /**
  */
 @RunWith(Parameterized.class)
-public class IngestSegmentFirehoseTest
+public class IngestSegmentFirehoseTest extends NullHandlingTest
 {
   private static final DimensionsSpec DIMENSIONS_SPEC = new DimensionsSpec(
       ImmutableList.of(

--- a/service.yml
+++ b/service.yml
@@ -8,4 +8,6 @@ github:
 semaphore:
   enable: true
   pipeline_enable: false
-  branches: []
+  branches:
+  - master
+  - /^.*-confluent$/

--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,11 @@
+name: druid
+lang: unknown
+lang_version: unknown
+git:
+  enable: true
+github:
+  enable: true
+semaphore:
+  enable: true
+  pipeline_enable: false
+  branches: []

--- a/web-console/README.md
+++ b/web-console/README.md
@@ -46,6 +46,7 @@ The console relies on [eslint](https://eslint.org) (and various plugins), [sass-
 #### Configuring WebStorm
 
 - **Preferences | Languages & Frameworks | JavaScript | Code Quality Tools | ESLint**
+
   - Select "Automatic ESLint Configuration"
   - Check "Run eslint --fix on save"
 
@@ -55,6 +56,7 @@ The console relies on [eslint](https://eslint.org) (and various plugins), [sass-
   - Check "On save"
 
 #### Configuring VS Code
+
 - Install `dbaeumer.vscode-eslint` extension
 - Install `esbenp.prettier-vscode` extension
 - Open User Settings (JSON) and set the following:
@@ -67,10 +69,11 @@ The console relies on [eslint](https://eslint.org) (and various plugins), [sass-
   ```
 
 #### Auto-fixing manually
+
 It is also possible to auto-fix and format code without making IDE changes by running the following script:
 
 - `npm run autofix` &mdash; run code linters and formatter
-  
+
 You could also run fixers individually:
 
 - `npm run eslint-fix` &mdash; run code linter and fix issues

--- a/web-console/console-config.js
+++ b/web-console/console-config.js
@@ -19,9 +19,9 @@
 window.consoleConfig = {
   exampleManifestsUrl: 'https://druid.apache.org/data/example-manifests-v2.tsv',
   /* future configs may go here */
-  "defaultQueryContext": {
-    "priority": -1,
-    "timeout": 30000,
-    "lane": "console"
-  }
+  defaultQueryContext: {
+    priority: -1,
+    timeout: 30000,
+    lane: 'console',
+  },
 };

--- a/web-console/console-config.js
+++ b/web-console/console-config.js
@@ -21,6 +21,7 @@ window.consoleConfig = {
   /* future configs may go here */
   "defaultQueryContext": {
     "priority": -1,
-    "timeout": 30000
+    "timeout": 30000,
+    "lane": "console"
   }
 };

--- a/web-console/console-config.js
+++ b/web-console/console-config.js
@@ -19,4 +19,8 @@
 window.consoleConfig = {
   exampleManifestsUrl: 'https://druid.apache.org/data/example-manifests-v2.tsv',
   /* future configs may go here */
+  "defaultQueryContext": {
+    "priority": -1,
+    "timeout": 30000
+  }
 };

--- a/web-console/src/ace-modes/hjson.js
+++ b/web-console/src/ace-modes/hjson.js
@@ -25,15 +25,15 @@
 ace.define(
   'ace/mode/hjson_highlight_rules',
   ['require', 'exports', 'module', 'ace/lib/oop', 'ace/mode/text_highlight_rules'],
-  function(acequire, exports, module) {
+  function (acequire, exports, module) {
     'use strict';
 
     var oop = acequire('../lib/oop');
     var TextHighlightRules = acequire('./text_highlight_rules').TextHighlightRules;
 
-    var HjsonHighlightRules = function() {
+    var HjsonHighlightRules = function () {
       this.$rules = {
-        start: [
+        'start': [
           {
             include: '#comments',
           },
@@ -277,19 +277,19 @@ ace.define(
     'ace/mode/text',
     'ace/mode/hjson_highlight_rules',
   ],
-  function(acequire, exports, module) {
+  function (acequire, exports, module) {
     'use strict';
 
     var oop = acequire('../lib/oop');
     var TextMode = acequire('./text').Mode;
     var HjsonHighlightRules = acequire('./hjson_highlight_rules').HjsonHighlightRules;
 
-    var Mode = function() {
+    var Mode = function () {
       this.HighlightRules = HjsonHighlightRules;
     };
     oop.inherits(Mode, TextMode);
 
-    (function() {
+    (function () {
       this.lineCommentStart = '//';
       this.blockComment = { start: '/*', end: '*/' };
       this.$id = 'ace/mode/hjson';

--- a/web-console/src/components/refresh-button/refresh-button.tsx
+++ b/web-console/src/components/refresh-button/refresh-button.tsx
@@ -34,15 +34,16 @@ const DELAYS: DelayLabel[] = [
 export interface RefreshButtonProps {
   onRefresh: (auto: boolean) => void;
   localStorageKey?: LocalStorageKeys;
+  defaultDelay?: number;
 }
 
 export const RefreshButton = React.memo(function RefreshButton(props: RefreshButtonProps) {
-  const { onRefresh, localStorageKey } = props;
+  const { onRefresh, localStorageKey, defaultDelay = 30000 } = props;
 
   return (
     <TimedButton
       className="refresh-button"
-      defaultDelay={30000}
+      defaultDelay={defaultDelay}
       label="Auto refresh every"
       delays={DELAYS}
       icon={IconNames.REFRESH}

--- a/web-console/src/views/ingestion-view/__snapshots__/ingestion-view.spec.tsx.snap
+++ b/web-console/src/views/ingestion-view/__snapshots__/ingestion-view.spec.tsx.snap
@@ -325,6 +325,7 @@ exports[`IngestionView matches snapshot 1`] = `
           </Blueprint4.Button>
         </Blueprint4.ButtonGroup>
         <Memo(RefreshButton)
+          defaultDelay={0}
           localStorageKey="task-refresh-rate"
           onRefresh={[Function]}
         />

--- a/web-console/src/views/ingestion-view/ingestion-view.tsx
+++ b/web-console/src/views/ingestion-view/ingestion-view.tsx
@@ -1194,6 +1194,7 @@ ORDER BY
               </ButtonGroup>
               <RefreshButton
                 localStorageKey={LocalStorageKeys.TASKS_REFRESH_RATE}
+                defaultDelay={0}
                 onRefresh={auto => {
                   if (auto && hasPopoverOpen()) return;
                   this.taskQueryManager.rerunLastQuery(auto);

--- a/web-console/src/views/sql-data-loader-view/schema-step/schema-step.tsx
+++ b/web-console/src/views/sql-data-loader-view/schema-step/schema-step.tsx
@@ -447,6 +447,7 @@ export const SchemaStep = function SchemaStep(props: SchemaStepProps) {
   useEffect(() => {
     if (!previewResultState.data) return;
     lastWorkingQueryPattern.current = ingestQueryPattern;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- excluding 'ingestQueryPattern'
   }, [previewResultState]);
 
   const unusedColumns = ingestQueryPattern


### PR DESCRIPTION
Apply Confluent patches on top of Druid 25.

Druid 25 release notes can be found [here](https://github.com/apache/druid/releases/tag/druid-25.0.0)

**Why suffix the branch wit `-rc1`?**
In case I messup, I don't have to work with IT to delete the `25.0.0-confluent` branch.
If [25.0.0-confluent-rc1](https://github.com/confluentinc/druid/tree/25.0.0-confluent-rc1) works out, I will just create a `25.0.0-confluent` branch from that one. If not, I'll give it another trying using `-rc2`

---
This section quotes @xvrl from slack,
### Some features of interest to us
1. Additional partition lag metrics for Kafka ingestion
2. Async task client for streaming ingestion (which I had already mentioned in November)
3. A fix for overlord leader-election locking up https://github.com/apache/druid/releases/tag/druid-25.0.0#25-ingestion-fixed-overlord-leader-election
4. A fix for tasks "getting stuck" and when overlord leader switches, which we have seen a few times https://github.com/apache/druid/releases/tag/druid-25.0.0#25-ingestion-streaming-tasks-resume-on-overlord-switch
5. Compaction now reduces the amount of disk usage https://github.com/apache/druid/releases/tag/druid-25.0.0#25-operations-compaction
6. An option to batch segment allocation, which can reduce ingestion lag when waiting for segment allocation https://github.com/apache/druid/releases/tag/druid-25.0.0#25-operations-batch-allocation
7. Improvements to reduce over-replication of segments during rebalancing https://github.com/apache/druid/releases/tag/druid-25.0.0#25-operations-segment-replication
8. Support for running tasks natively one k8s, which means we don't need to run middle-managers for compaction tasks anymore, and can bin-pack those workloads anywhere https://github.com/apache/druid/releases/tag/druid-25.0.0#25-highlights-kubernetes-native-tasks

### Caution
Task management and segment discovery will default to http by default https://github.com/apache/druid/releases/tag/druid-25.0.0#25-upgrade-segment-discovery

---

### Additional commits
1. https://github.com/confluentinc/druid/pull/136/commits/a9acfc3db8b56847e10cb0dadf57bc6c8224fb92 - Fix lint issue in CI/CD
The lint would fail. A similar fix has been made on druid 26. See [here](https://github.com/apache/druid/blob/druid-26.0.0/web-console/src/views/sql-data-loader-view/schema-step/schema-step.tsx#L519). I didn't cherry-pick the corresponding [commit](https://github.com/apache/druid/pull/13762) from apache/druid because it was very large and changes a lot of files.
2. https://github.com/confluentinc/druid/pull/136/commits/68fbe4f66d540c2bed54606723be69eabeb5c1ae - Fix jest and prettify checks
These changes were created by running the following commands,
```
npx prettier --write .
npm run jest -- -u
```

---
### Testing

<details>
<summary>
mvn clean package -DskipTests -T1C -X
</summary>

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Druid 25.0.0:
[INFO]
[INFO] Druid .............................................. SUCCESS [  9.509 s]
[INFO] druid-core ......................................... SUCCESS [ 35.928 s]
[INFO] druid-hll .......................................... SUCCESS [ 18.039 s]
[INFO] extendedset ........................................ SUCCESS [ 18.270 s]
[INFO] druid-processing ................................... SUCCESS [01:03 min]
[INFO] druid-aws-common ................................... SUCCESS [ 18.944 s]
[INFO] druid-gcp-common ................................... SUCCESS [ 18.145 s]
[INFO] druid-server ....................................... SUCCESS [ 45.045 s]
[INFO] druid-indexing-hadoop .............................. SUCCESS [02:06 min]
[INFO] druid-indexing-service ............................. SUCCESS [01:50 min]
[INFO] druid-sql .......................................... SUCCESS [01:15 min]
[INFO] druid-services ..................................... SUCCESS [ 29.801 s]
[INFO] druid-orc-extensions ............................... SUCCESS [01:36 min]
[INFO] druid-avro-extensions .............................. SUCCESS [01:48 min]
[INFO] druid-parquet-extensions ........................... SUCCESS [01:37 min]
[INFO] druid-protobuf-extensions .......................... SUCCESS [ 15.048 s]
[INFO] druid-s3-extensions ................................ SUCCESS [ 37.391 s]
[INFO] druid-kinesis-indexing-service ..................... SUCCESS [ 14.989 s]
[INFO] druid-azure-extensions ............................. SUCCESS [ 35.892 s]
[INFO] druid-google-extensions ............................ SUCCESS [ 35.632 s]
[INFO] druid-hdfs-storage ................................. SUCCESS [01:36 min]
[INFO] druid-datasketches ................................. SUCCESS [ 31.345 s]
[INFO] druid-histogram .................................... SUCCESS [ 27.697 s]
[INFO] mysql-metadata-storage ............................. SUCCESS [ 36.272 s]
[INFO] druid-kafka-indexing-service ....................... SUCCESS [ 15.099 s]
[INFO] druid-basic-security ............................... SUCCESS [ 38.704 s]
[INFO] druid-lookups-cached-global ........................ SUCCESS [ 38.533 s]
[INFO] druid-testing-tools ................................ SUCCESS [ 23.734 s]
[INFO] simple-client-sslcontext ........................... SUCCESS [ 35.615 s]
[INFO] druid-multi-stage-query ............................ SUCCESS [ 33.586 s]
[INFO] druid-integration-tests ............................ SUCCESS [ 15.870 s]
[INFO] druid-stats ........................................ SUCCESS [ 26.579 s]
[INFO] druid-benchmarks ................................... SUCCESS [16:36 min]
[INFO] web-console ........................................ SUCCESS [03:13 min]
[INFO] druid-kubernetes-extensions ........................ SUCCESS [ 40.437 s]
[INFO] druid-bloom-filter ................................. SUCCESS [ 26.514 s]
[INFO] druid-kerberos ..................................... SUCCESS [ 37.684 s]
[INFO] druid-pac4j ........................................ SUCCESS [01:32 min]
[INFO] druid-kafka-extraction-namespace ................... SUCCESS [ 27.751 s]
[INFO] postgresql-metadata-storage ........................ SUCCESS [ 36.529 s]
[INFO] druid-lookups-cached-single ........................ SUCCESS [ 37.795 s]
[INFO] druid-ec2-extensions ............................... SUCCESS [ 12.903 s]
[INFO] druid-aws-rds-extensions ........................... SUCCESS [ 18.024 s]
[INFO] druid-ranger-security .............................. SUCCESS [ 27.928 s]
[INFO] druid-catalog ...................................... SUCCESS [ 27.944 s]
[INFO] druid-compressed-bigdecimal ........................ SUCCESS [ 26.610 s]
[INFO] druid-influx-extensions ............................ SUCCESS [ 18.217 s]
[INFO] druid-cassandra-storage ............................ SUCCESS [ 18.025 s]
[INFO] dropwizard-emitter ................................. SUCCESS [ 23.805 s]
[INFO] druid-cloudfiles-extensions ........................ SUCCESS [ 17.012 s]
[INFO] graphite-emitter ................................... SUCCESS [ 19.587 s]
[INFO] druid-distinctcount ................................ SUCCESS [ 10.604 s]
[INFO] statsd-emitter ..................................... SUCCESS [ 17.709 s]
[INFO] druid-time-min-max ................................. SUCCESS [ 18.464 s]
[INFO] druid-virtual-columns .............................. SUCCESS [ 10.741 s]
[INFO] druid-thrift-extensions ............................ SUCCESS [01:37 min]
[INFO] ambari-metrics-emitter ............................. SUCCESS [ 18.516 s]
[INFO] sqlserver-metadata-storage ......................... SUCCESS [ 19.559 s]
[INFO] kafka-emitter ...................................... SUCCESS [ 24.949 s]
[INFO] druid-redis-cache .................................. SUCCESS [ 26.273 s]
[INFO] druid-opentsdb-emitter ............................. SUCCESS [ 18.605 s]
[INFO] materialized-view-maintenance ...................... SUCCESS [ 12.990 s]
[INFO] materialized-view-selection ........................ SUCCESS [ 10.710 s]
[INFO] druid-momentsketch ................................. SUCCESS [ 16.658 s]
[INFO] druid-moving-average-query ......................... SUCCESS [ 24.724 s]
[INFO] tdigestsketch ...................................... SUCCESS [ 24.468 s]
[INFO] druid-influxdb-emitter ............................. SUCCESS [ 10.831 s]
[INFO] gce-extensions ..................................... SUCCESS [ 12.939 s]
[INFO] aliyun-oss-extensions .............................. SUCCESS [06:06 min]
[INFO] prometheus-emitter ................................. SUCCESS [ 24.670 s]
[INFO] opentelemetry-emitter .............................. SUCCESS [ 27.024 s]
[INFO] druid-kubernetes-overlord-extensions ............... SUCCESS [ 15.149 s]
[INFO] druid-opentelemetry-extensions ..................... SUCCESS [ 24.180 s]
[INFO] druid-opencensus-extensions ........................ SUCCESS [ 46.575 s]
[INFO] confluent-extensions ............................... SUCCESS [ 10.419 s]
[INFO] distribution ....................................... SUCCESS [ 28.154 s]
[INFO] druid-it-tools ..................................... SUCCESS [ 27.928 s]
[INFO] druid-it-image ..................................... SUCCESS [ 11.596 s]
[INFO] druid-it-cases ..................................... SUCCESS [ 12.904 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21:15 min (Wall Clock)
[INFO] Finished at: 2023-05-30T11:38:07+05:30
[INFO] ------------------------------------------------------------------------
```
</details>
