### PR TITLE
workaround for KafkaInputFormat not passing through value timestamp

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
@@ -33,6 +33,7 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
+import org.apache.druid.segment.column.ColumnHolder;
 
 import javax.annotation.Nullable;
 
@@ -114,6 +115,14 @@ public class KafkaInputReader implements InputEntityReader
             );
           }
           Map<String, Object> event = new HashMap<>(headerKeyList);
+
+          // pass through the original InputRow timestamp returned by the value InputFormat as the __time field
+          // this allows the TimestampSpec to access the original valueRow timestamp if it is not present separately in
+          // the map returned by valueRow.getEvent().
+          // TODO: figure out if this should be called __time or something else in case the InputFormat defines its own
+          //  __time field that is different from valueRow.getTimestamp().
+          event.put(ColumnHolder.TIME_COLUMN_NAME, valueRow.getTimestampFromEpoch());
+
           /* Currently we prefer payload attributes if there is a collision in names.
               We can change this beahvior in later changes with a config knob. This default
               behavior lets easy porting of existing inputFormats to the new one without any changes.
@@ -121,6 +130,7 @@ public class KafkaInputReader implements InputEntityReader
           event.putAll(valueRow.getEvent());
 
           HashSet<String> newDimensions = new HashSet<String>(valueRow.getDimensions());
+          newDimensions.add(ColumnHolder.TIME_COLUMN_NAME);
           newDimensions.addAll(headerKeyList.keySet());
           // Remove the dummy timestamp added in KafkaInputFormat
           newDimensions.remove(KafkaInputFormat.DEFAULT_AUTO_TIMESTAMP_STRING);

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
@@ -116,11 +116,11 @@ public class KafkaInputReader implements InputEntityReader
           }
           Map<String, Object> event = new HashMap<>(headerKeyList);
 
-          // pass through the original InputRow timestamp returned by the value InputFormat as the __time field
-          // this allows the TimestampSpec to access the original valueRow timestamp if it is not present separately in
-          // the map returned by valueRow.getEvent().
-          // TODO: figure out if this should be called __time or something else in case the InputFormat defines its own
-          //  __time field that is different from valueRow.getTimestamp().
+          /* pass through the original InputRow timestamp returned by the value InputFormat as the __time field
+             this allows the TimestampSpec to access the original valueRow timestamp if it is not present separately in
+             the map returned by valueRow.getEvent().
+             TODO: figure out if this should be called __time or something else in case the InputFormat defines its own
+             __time field that is different from valueRow.getTimestamp(). */
           event.put(ColumnHolder.TIME_COLUMN_NAME, valueRow.getTimestampFromEpoch());
 
           /* Currently we prefer payload attributes if there is a collision in names.

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -21,11 +21,14 @@ package org.apache.druid.data.input.kafkainput;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.apache.druid.data.input.ColumnsFilter;
+import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -39,19 +42,23 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.common.parsers.TimestampParser;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 
 public class KafkaInputFormatTest
 {
@@ -546,10 +553,106 @@ public class KafkaInputFormatTest
     }
   }
 
+  /**
+   * Some InputFormats return InputRow objects with timestamps readable only via InputRow.getTimestamp()
+   * (e.g. when parsing complex formats with native timestamps). In those cases the timestampSpec cannot access
+   * the timestamp for input rows returned by the valueFormat. As a workaround KafkaInputFormat injects the native
+   * row timestamp as a __time field to make it accessible via the timestampSpec.
+   * @throws IOException
+   */
+  @Test
+  public void testValueTimestampPassthrough() throws IOException
+  {
+    format = new KafkaInputFormat(
+        null,
+        null,
+        // Value Format
+        new TimestampExtractingInputFormat(),
+        null,
+        null,
+        null
+    );
+
+    final byte[] payload = StringUtils.toUtf8(
+        "{\n"
+        + "    \"timestamp\": \"2023-06-21\",\n"
+        + "    \"bar\": null,\n"
+        + "    \"foo\": \"x\",\n"
+        + "    \"baz\": 4,\n"
+        + "    \"o\": {\n"
+        + "        \"mg\": 1\n"
+        + "    }\n"
+        + "}");
+
+    inputEntity = new KafkaRecordEntity(new ConsumerRecord<>(
+        "sample", 0, 0, timestamp,
+        null, 0, 0,
+        null, payload, new RecordHeaders(), Optional.empty()));
+
+    final InputEntityReader reader = format.createReader(
+        new InputRowSchema(
+            new TimestampSpec("__time", "millis", null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
+                "bar", "foo"
+            ))),
+            ColumnsFilter.all()
+        ),
+        newSettableByteEntity(inputEntity),
+        null
+    );
+
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      while (iterator.hasNext()) {
+        final InputRow row = iterator.next();
+        // verify the timestamp is the one passed through via InputRow.getTimestamp(), and the __time field is present
+        Assert.assertEquals(DateTimes.of("2023-06-21"), row.getTimestamp());
+        Assert.assertEquals(DateTimes.of("2023-06-21").getMillis(), row.getRaw("__time"));
+      }
+    }
+  }
+
   private SettableByteEntity<KafkaRecordEntity> newSettableByteEntity(KafkaRecordEntity kafkaRecordEntity)
   {
     SettableByteEntity<KafkaRecordEntity> settableByteEntity = new SettableByteEntity<>();
     settableByteEntity.setEntity(kafkaRecordEntity);
     return settableByteEntity;
+  }
+
+  /**
+   * This input format exists solely to test the ability to retrieve an input row's timestamp,
+   * (i.e. the value returned by InputRow.getTimestampFromEpoch() via the KafkaInputFormat)
+   * <p>
+   * It extends a basic JsonInputFormat to parse the "timestamp" field, and use it to set the timestamp on
+   * the input row returned by the input format.
+   */
+  static class TimestampExtractingInputFormat extends JsonInputFormat {
+    public TimestampExtractingInputFormat() {
+      super(null, null, null, false);
+    }
+
+    @Override
+    public InputEntityReader createReader(InputRowSchema inputRowSchema, InputEntity source, File temporaryDirectory)
+    {
+      InputEntityReader reader = super.createReader(inputRowSchema, source, temporaryDirectory);
+      Function<Object, DateTime> timestampParser = TimestampParser.createObjectTimestampParser("auto");
+      return new InputEntityReader()
+      {
+        @Override
+        public CloseableIterator<InputRow> read() throws IOException
+        {
+          return reader.read().map(inputRow -> new MapBasedInputRow(
+              timestampParser.apply(inputRow.getRaw("timestamp")),
+              inputRow.getDimensions(),
+              ((MapBasedInputRow)inputRow).getEvent()
+          ));
+        }
+
+        @Override
+        public CloseableIterator<InputRowListPlusRawValues> sample() throws IOException
+        {
+          throw new UnsupportedOperationException();
+        }
+      };
+    }
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -625,8 +625,10 @@ public class KafkaInputFormatTest
    * It extends a basic JsonInputFormat to parse the "timestamp" field, and use it to set the timestamp on
    * the input row returned by the input format.
    */
-  static class TimestampExtractingInputFormat extends JsonInputFormat {
-    public TimestampExtractingInputFormat() {
+  static class TimestampExtractingInputFormat extends JsonInputFormat
+  {
+    public TimestampExtractingInputFormat()
+    {
       super(null, null, null, false);
     }
 
@@ -643,7 +645,7 @@ public class KafkaInputFormatTest
           return reader.read().map(inputRow -> new MapBasedInputRow(
               timestampParser.apply(inputRow.getRaw("timestamp")),
               inputRow.getDimensions(),
-              ((MapBasedInputRow)inputRow).getEvent()
+              ((MapBasedInputRow) inputRow).getEvent()
           ));
         }
 

--- a/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ServerManagerTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.client.cache.CachePopulatorStats;
 import org.apache.druid.client.cache.ForegroundCachePopulator;
 import org.apache.druid.client.cache.LocalCacheProvider;
 import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.common.config.NullHandlingTest;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
@@ -123,7 +124,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  */
-public class ServerManagerTest
+public class ServerManagerTest extends NullHandlingTest
 {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();


### PR DESCRIPTION
Using KafkaInputFormat it is currently not possible to access the timestamp of the InputRow returned by the value InputFormat unless it is present as a separate field in the InputRow.

This adds a workaround to inject the value timestamp as the __time field so it can be accessed via the timestampSpec.
