### PR TITLE
Downgrade busybox version to fix k8s IT (#14518)

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -28,7 +28,7 @@ COPY ./target/apache-druid-${VERSION}-bin.tar.gz .
 RUN tar -zxf /src/apache-druid-${VERSION}-bin.tar.gz -C /opt \
  && ln -s /opt/apache-druid-${VERSION} /opt/druid
 
-FROM busybox:1.35.0-glibc as busybox
+FROM busybox:1.34.1-glibc as busybox
 
 FROM gcr.io/distroless/java$JDK_VERSION-debian11
 LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"


### PR DESCRIPTION
Downgrading busybox version in Dockerfile to fix following error,

 => ERROR [stage-2  3/10] RUN ["/busybox/busybox", "--install", "/bin"]                                                                          0.4s
------
 > [stage-2  3/10] RUN ["/busybox/busybox", "--install", "/bin"]:
#0 0.293 /busybox/busybox: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /busybox/busybox)
#0 0.293 /busybox/busybox: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /busybox/busybox)
This PR has:

 been self-reviewed.
 using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
 added documentation for new or modified features or behaviors.
 a release note entry in the PR description.
 added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
 added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
 added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
 added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
 added integration tests.
 been tested in a test Druid cluster.