### PR TITLE
Passing TARGETARCH in build_args to Docker build

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -28,7 +28,7 @@ COPY ./target/apache-druid-${VERSION}-bin.tar.gz .
 RUN tar -zxf /src/apache-druid-${VERSION}-bin.tar.gz -C /opt \
  && ln -s /opt/apache-druid-${VERSION} /opt/druid
 
-FROM busybox:1.35.0-glibc as busybox
+FROM busybox:1.34.1-glibc as busybox
 
 FROM gcr.io/distroless/java$JDK_VERSION-debian11
 LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -51,6 +51,7 @@
         <!-- the default value is a repeated flag from the command line, since blank value is not allowed -->
         <druid.distribution.pulldeps.opts>--clean</druid.distribution.pulldeps.opts>
         <docker.jdk.version>17</docker.jdk.version>
+        <targetarch>amd64</targetarch>
     </properties>
 
     <build>
@@ -795,6 +796,7 @@
                   <buildArgs>
                     <VERSION>${project.version}</VERSION>
                     <JDK_VERSION>${docker.jdk.version}</JDK_VERSION>
+                      <TARGETARCH>${targetarch}</TARGETARCH>
                   </buildArgs>
                 </configuration>
               </plugin>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -796,7 +796,7 @@
                   <buildArgs>
                     <VERSION>${project.version}</VERSION>
                     <JDK_VERSION>${docker.jdk.version}</JDK_VERSION>
-                      <TARGETARCH>${targetarch}</TARGETARCH>
+                    <TARGETARCH>${targetarch}</TARGETARCH>
                   </buildArgs>
                 </configuration>
               </plugin>


### PR DESCRIPTION
Passes the parameter TARGETARCH as BUILD_ARGS, which is needed for distribution Docker build. 

The dockerfile for distribution was added with this code: https://github.com/confluentinc/druid/blob/515ad51686876dbbbd8fd17782e29c709455a92e/distribution/docker/Dockerfile#L40

By default, a null value is being passed to the TARGETARCH which results in the docker build failing. 

