### PR TITLE
removing use of semaphore cache as the public semaphore will not have cache

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -40,9 +40,9 @@ blocks:
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
-            - tar zcvf cache-post.tgz .m2 target
             - artifact delete project cache.tgz || true
             - artifact push project cache.tgz
+            - tar zcvf cache-post-install.tgz .m2 target
             - artifact delete workflow cache-post-install.tgz || true
             - artifact push workflow cache-post-install.tgz
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,11 +33,9 @@ blocks:
       jobs:
         - name: "Install"
           commands:
-            - cache restore
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
-            - cache store
 
   - name: "Tests"
     task:
@@ -47,7 +45,6 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
-          - cache restore
       jobs:
         - name: "animal sniffer checks"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ blocks:
           commands:
             - cache restore
             - tar zcvf cache.tgz .m2 target
-            - artifact delete project cache.tgz
+            # - artifact delete project cache.tgz
             - artifact push project cache.tgz
             - rm ~/.m2/settings.xml
             - >

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,11 +30,11 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
-          - rm ~/.m2/settings.xml
       jobs:
         - name: "Install"
           commands:
             - cache restore            
+            - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
@@ -48,6 +48,7 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
+          - cache restore
           - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,16 +36,16 @@ blocks:
           commands:
             # - artifact pull project cache.tgz
             # - tar zxf cache.tgz
-            - rm ~/.m2/settings.xml
+            # - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
-            - tar zcf cache-post-install.tgz .m2 target
+            # - tar zcf cache-post-install.tgz .m2 target
             # - artifact delete workflow cache-post-install.tgz || true
             # - artifact push workflow cache-post-install.tgz
-            - mv cache-post-install.tgz cache.tgz
-            - artifact delete project cache.tgz || true
-            - artifact push project cache.tgz
+            # - mv cache-post-install.tgz cache.tgz
+            # - artifact delete project cache.tgz || true
+            # - artifact push project cache.tgz
 
   - name: "Tests"
     task:
@@ -55,9 +55,9 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
-          - artifact pull workflow cache-post-install.tgz
-          - tar zxf cache-post-install.tgz
-          - rm ~/.m2/settings.xml
+          # - artifact pull workflow cache-post-install.tgz
+          # - tar zxf cache-post-install.tgz
+          # - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,15 +34,12 @@ blocks:
       jobs:
         - name: "Install"
           commands:
-            - cache restore
-            - tar zcvf cache.tgz .m2 target
-            - artifact delete project cache.tgz
-            - artifact push project cache.tgz
-            - rm ~/.m2/settings.xml
+            - artifact pull project cache.tgz
+            - tar zxvf cache.tgz
+            # - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
-            - cache store
             - tar zcvf cache-post.tgz .m2 target
             - artifact delete project cache-post.tgz
             - artifact push project cache-post.tgz

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -41,8 +41,10 @@ blocks:
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
             - tar zcvf cache-post.tgz .m2 target
-            - artifact delete project cache-post.tgz
-            - artifact push project cache-post.tgz
+            - artifact delete project cache.tgz || true
+            - artifact push project cache.tgz
+            - artifact delete workflow cache-post-install.tgz || true
+            - artifact push workflow cache-post-install.tgz
 
   - name: "Tests"
     task:
@@ -52,8 +54,8 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
-          - artifact pull project cache.tgz
-          - tar zxvf cache.tgz
+          - artifact pull workflow cache-post-install.tgz
+          - tar zxvf cache-post-install.tgz
           - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -40,6 +40,8 @@ blocks:
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
+            # downstream tests depend on artifacts installed by mvn install into .m2
+            # also cache target to avoid the cost of recompiling tests
             - tar zcf cache-post-install.tgz .m2 target
             - artifact push workflow cache-post-install.tgz
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,15 +34,15 @@ blocks:
       jobs:
         - name: "Install"
           commands:
-            - artifact pull project cache.tgz
-            - tar zxf cache.tgz
+            # - artifact pull project cache.tgz
+            # - tar zxf cache.tgz
             - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
             - tar zcf cache-post-install.tgz .m2 target
-            - artifact delete workflow cache-post-install.tgz || true
-            - artifact push workflow cache-post-install.tgz
+            # - artifact delete workflow cache-post-install.tgz || true
+            # - artifact push workflow cache-post-install.tgz
             - mv cache-post-install.tgz cache.tgz
             - artifact delete project cache.tgz || true
             - artifact push project cache.tgz

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,6 +30,7 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
+          - rm ~/.m2/settings.xml
       jobs:
         - name: "Install"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,18 +34,14 @@ blocks:
       jobs:
         - name: "Install"
           commands:
-            # - artifact pull project cache.tgz
-            # - tar zxf cache.tgz
-            # - rm ~/.m2/settings.xml
+            # This is a change meant to validate semaphore public builds
+            # so thus removing configurations for Confluent's internal CodeArtifact
+            - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
-            # - tar zcf cache-post-install.tgz .m2 target
-            # - artifact delete workflow cache-post-install.tgz || true
-            # - artifact push workflow cache-post-install.tgz
-            # - mv cache-post-install.tgz cache.tgz
-            # - artifact delete project cache.tgz || true
-            # - artifact push project cache.tgz
+            - tar zcf cache-post-install.tgz .m2 target
+            - artifact push workflow cache-post-install.tgz
 
   - name: "Tests"
     task:
@@ -55,9 +51,9 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
-          # - artifact pull workflow cache-post-install.tgz
-          # - tar zxf cache-post-install.tgz
-          # - rm ~/.m2/settings.xml
+          - artifact pull workflow cache-post-install.tgz
+          - tar zxf cache-post-install.tgz
+          - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,7 +44,7 @@ blocks:
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
             - cache store
             - tar zcvf cache-post.tgz .m2 target
-            - artifact delete project cache-post.tgz
+            # - artifact delete project cache-post.tgz
             - artifact push project cache-post.tgz
 
   - name: "Tests"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,6 +36,7 @@ blocks:
           commands:
             - cache restore
             - tar zcvf cache.tgz .m2 target
+            - artifact delete project cache.tgz
             - artifact push project cache.tgz
             - rm ~/.m2/settings.xml
             - >
@@ -43,6 +44,7 @@ blocks:
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
             - cache store
             - tar zcvf cache-post.tgz .m2 target
+            - artifact delete project cache-post.tgz
             - artifact push project cache-post.tgz
 
   - name: "Tests"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,6 +36,7 @@ blocks:
           commands:
             - artifact pull project cache.tgz
             - tar zxf cache.tgz
+            - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
@@ -56,6 +57,7 @@ blocks:
           - checkout
           - artifact pull workflow cache-post-install.tgz
           - tar zxf cache-post-install.tgz
+          - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -52,7 +52,8 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
-          # - cache restore
+          - artifact pull project cache.tgz
+          - tar zxvf cache.tgz
           - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -40,11 +40,12 @@ blocks:
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
-            - artifact delete project cache.tgz || true
-            - artifact push project cache.tgz
             - tar zcvf cache-post-install.tgz .m2 target
             - artifact delete workflow cache-post-install.tgz || true
             - artifact push workflow cache-post-install.tgz
+            - mv cache-post-install.tgz cache.tgz
+            - artifact delete project cache.tgz || true
+            - artifact push project cache.tgz
 
   - name: "Tests"
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,8 @@ name: Apache Druid
 agent:
   machine:
     type: s1-prod-ubuntu20-04-amd64-1
-
+execution_time_limit:
+  hours: 3
 blocks:
   - name: "Install"
     task:
@@ -33,12 +34,16 @@ blocks:
       jobs:
         - name: "Install"
           commands:
-            - cache restore            
-            - rm ~/.m2/settings.xml
+            - cache restore
+            - tar zcvf cache.tgz .m2 target
+            - artifact push project cache.tgz
+            # - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
             - cache store
+            - tar zcvf cache-post.tgz .m2 target
+            - artifact push project cache-post.tgz
 
   - name: "Tests"
     task:
@@ -49,7 +54,6 @@ blocks:
           - sem-version java 17
           - checkout
           - cache restore
-          - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -35,12 +35,11 @@ blocks:
         - name: "Install"
           commands:
             - artifact pull project cache.tgz
-            - tar zxvf cache.tgz
-            - rm ~/.m2/settings.xml
+            - tar zxf cache.tgz
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
-            - tar zcvf cache-post-install.tgz .m2 target
+            - tar zcf cache-post-install.tgz .m2 target
             - artifact delete workflow cache-post-install.tgz || true
             - artifact push workflow cache-post-install.tgz
             - mv cache-post-install.tgz cache.tgz
@@ -56,8 +55,7 @@ blocks:
           - sem-version java 17
           - checkout
           - artifact pull workflow cache-post-install.tgz
-          - tar zxvf cache-post-install.tgz
-          - rm ~/.m2/settings.xml
+          - tar zxf cache-post-install.tgz
       jobs:
         - name: "animal sniffer checks"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,7 +37,7 @@ blocks:
             - cache restore
             - tar zcvf cache.tgz .m2 target
             - artifact push project cache.tgz
-            # - rm ~/.m2/settings.xml
+            - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ blocks:
           commands:
             - cache restore
             - tar zcvf cache.tgz .m2 target
-            # - artifact delete project cache.tgz
+            - artifact delete project cache.tgz
             - artifact push project cache.tgz
             - rm ~/.m2/settings.xml
             - >

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -46,6 +46,7 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
+          - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -55,6 +55,8 @@ blocks:
           - checkout
           - artifact pull workflow cache-post-install.tgz
           - tar zxf cache-post-install.tgz
+          # This is a change meant to validate semaphore public builds
+          # so thus removing configurations for Confluent's internal CodeArtifact
           - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -44,7 +44,7 @@ blocks:
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
             - cache store
             - tar zcvf cache-post.tgz .m2 target
-            # - artifact delete project cache-post.tgz
+            - artifact delete project cache-post.tgz
             - artifact push project cache-post.tgz
 
   - name: "Tests"
@@ -55,7 +55,8 @@ blocks:
           - echo $SEMAPHORE_WORKFLOW_ID
           - sem-version java 17
           - checkout
-          - cache restore
+          # - cache restore
+          - rm ~/.m2/settings.xml
       jobs:
         - name: "animal sniffer checks"
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ blocks:
           commands:
             - artifact pull project cache.tgz
             - tar zxvf cache.tgz
-            # - rm ~/.m2/settings.xml
+            - rm ~/.m2/settings.xml
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,9 +34,11 @@ blocks:
       jobs:
         - name: "Install"
           commands:
+            - cache restore            
             - >
               MAVEN_OPTS="${MAVEN_OPTS} -Xmx3000m" ${MVN} clean install
               -q -ff ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C
+            - cache store
 
   - name: "Tests"
     task:


### PR DESCRIPTION
removing use of semaphore cache as the public semaphore will not have cache

* utilize workflow level caching to publish the built
artifacts to the tests. otherwise turn off all caching of .m2 etc

* remove .m2/settings.xml to ensure build passes without internal artifact store