### PR TITLE
Revert "Trying to add required flags to run druid using java 17 (#130)"

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -163,32 +163,6 @@ if [ -n "$DRUID_MAXNEWSIZE" ]; then setJavaKey ${SERVICE} -XX:MaxNewSize -XX:Max
 if [ -n "$DRUID_NEWSIZE" ]; then setJavaKey ${SERVICE} -XX:NewSize -XX:NewSize=${DRUID_NEWSIZE}; fi
 if [ -n "$DRUID_MAXDIRECTMEMORYSIZE" ]; then setJavaKey ${SERVICE} -XX:MaxDirectMemorySize -XX:MaxDirectMemorySize=${DRUID_MAXDIRECTMEMORYSIZE}; fi
 
-# If java version is 17 or greater, add command line args to enable class loading via Guice
-JAVA_MAJOR="$(java -version 2>&1 | sed -n -E 's/.* version "([^."]*).*/\1/p')"
-
-if [ "$JAVA_MAJOR" != "" ] && [ "$JAVA_MAJOR" -ge "17" ]
-then
-  # Must disable strong encapsulation for certain packages on Java 17.
-  JAVA_OPTS="--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
-    --add-exports=java.base/jdk.internal.perf=ALL-UNNAMED \
-    --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED \
-    --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED \
-    --add-opens=java.base/java.nio=ALL-UNNAMED \
-    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
-    --add-opens=java.base/java.io=ALL-UNNAMED \
-    --add-opens=java.base/java.lang=ALL-UNNAMED \
-    --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
-    $JAVA_OPTS"
-elif [ "$JAVA_MAJOR" != "" ] && [ "$JAVA_MAJOR" -ge "11" ]
-then
-  # Parameters below are required to use datasketches-memory as a library
-  JAVA_OPTS="$JAVA_OPTS \
-    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
-    --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED \
-    --add-opens=java.base/java.nio=ALL-UNNAMED \
-    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
-fi
-
 # Combine options from jvm.config and those given as JAVA_OPTS
 # If a value is specified in both then JAVA_OPTS will take precedence when using OpenJDK
 # However this behavior is not part of the spec and is thus implementation specific


### PR DESCRIPTION
This reverts our custom patch from commit 7cf2de4081bc9196471436654bf5ebe268611e80.

The necessary Java 17 exports are now included as part of 25.0.0 in https://github.com/confluentinc/druid/blob/25.0.0-confluent/examples/bin/run-java#L27-L56 which is now called by the druid.sh docker startup script as well.

The exports for java.base/jdk.internal.perf=ALL-UNNAMED are no longer needed since https://github.com/apache/druid/pull/12481#discussion_r859396192