### PR TITLE
OBSDATA-1365: add support for debian based base images

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -58,7 +58,7 @@ LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 
 COPY --from=busybox /bin/busybox /busybox/busybox
 RUN ["/busybox/busybox", "sh", "-c", "if [ ! -x \"$(command -v bash)\" ]; then \
-                                        exec /busybox/busybox --install /bin; \
+                                        /busybox/busybox --install /bin; \
                                       else \
                                         rm /busybox/busybox; \
                                       fi;"]

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -104,7 +104,7 @@ RUN mkdir /opt/druid/var /opt/shared \
 
 # Install iproute2 to get the ip command needed to set config of druid.host IP address
 # Command needed in druid.sh Line 140;
-RUN if [ -x "$(command -v apt)" ] && [ ! -x "$(command -v ip)" ]; then \
+RUN if [ ! -x "$(command -v ip)" ]; then \
       apt update \
       && apt install -y iproute2; \
     fi;

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -18,6 +18,7 @@
 #
 
 ARG JDK_VERSION=11
+ARG BASE_IMAGE=gcr.io/distroless/java$JDK_VERSION-debian11
 
 # The platform is explicitly specified as x64 to build the Druid distribution.
 # This is because it's not able to build the distribution on arm64 due to dependency problem of web-console. See: https://github.com/apache/druid/issues/13012
@@ -51,12 +52,19 @@ RUN --mount=type=cache,target=/root/.m2 VERSION=$(mvn -B -q org.apache.maven.plu
 
 FROM busybox:1.34.1-glibc as busybox
 
-FROM gcr.io/distroless/java$JDK_VERSION-debian11
+FROM $BASE_IMAGE
+ARG JDK_VERSION
+ARG BASE_IMAGE
+
 LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 
 COPY --from=busybox /bin/busybox /busybox/busybox
-RUN ["/busybox/busybox", "--install", "/bin"]
-
+RUN ["/busybox/busybox", "sh", "-c", "if [ $BASE_IMAGE = gcr.io/distroless/java$JDK_VERSION-debian11 ]; then \
+                                        exec /busybox/busybox --install /bin; \
+                                      else \
+                                        rm /busybox/busybox \
+                                        && exit; \
+                                      fi;"]
 # Predefined builtin arg, see: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG TARGETARCH
 
@@ -65,19 +73,26 @@ ARG TARGETARCH
 # Although bash-static supports multiple platforms, but there's no need for us to support all those platform, amd64 and arm64 are enough.
 #
 ARG BASH_URL_BASE="https://github.com/robxu9/bash-static/releases/download/5.1.016-1.2.3"
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      BASH_URL="${BASH_URL_BASE}/bash-linux-aarch64" ; \
-    elif [ "$TARGETARCH" = "amd64" ]; then \
-      BASH_URL="${BASH_URL_BASE}/bash-linux-x86_64" ; \
-    else \
-      echo "Unsupported architecture ($TARGETARCH)" && exit 1; \
-    fi; \
-    echo "Downloading bash-static from ${BASH_URL}" \
-    && wget ${BASH_URL} -O /bin/bash \
-    && chmod 755 /bin/bash
+RUN if [ "$BASE_IMAGE" = "gcr.io/distroless/java$JDK_VERSION-debian11" ]; then \
+      if [ "$TARGETARCH" = "arm64" ]; then \
+        BASH_URL="${BASH_URL_BASE}/bash-linux-aarch64" ; \
+      elif [ "$TARGETARCH" = "amd64" ]; then \
+        BASH_URL="${BASH_URL_BASE}/bash-linux-x86_64" ; \
+      else \
+        echo "Unsupported architecture ($TARGETARCH)" && exit 1; \
+      fi; \
+      echo "Downloading bash-static from ${BASH_URL}" \
+      && wget ${BASH_URL} -O /bin/bash \
+      && chmod 755 /bin/bash; \
+    fi;
 
-RUN addgroup -S -g 1000 druid \
- && adduser -S -u 1000 -D -H -h /opt/druid -s /bin/sh -g '' -G druid druid
+RUN if [ "$BASE_IMAGE" = "gcr.io/distroless/java$JDK_VERSION-debian11" ]; then \
+      addgroup -S -g 1000 druid \
+      && adduser -S -u 1000 -D -H -h /opt/druid -s /bin/sh -g '' -G druid druid; \
+    else \
+      groupadd --force --system --gid 1000 druid \
+      && useradd --system --uid 1000 -M --home /opt/druid --shell /bin/sh -c '' --gid druid druid; \
+    fi;
 
 COPY --chown=druid:druid --from=builder /opt /opt
 COPY distribution/docker/druid.sh /druid.sh
@@ -89,6 +104,12 @@ COPY distribution/docker/peon.sh /peon.sh
 RUN mkdir /opt/druid/var /opt/shared \
  && chown druid:druid /opt/druid/var /opt/shared \
  && chmod 775 /opt/druid/var /opt/shared
+
+# Install iproute2 library if busybox not installed
+RUN if [ "$BASE_IMAGE" != "gcr.io/distroless/java$JDK_VERSION-debian11" ]; then \
+     apt update \
+     && apt install -y iproute2; \
+    fi;
 
 USER druid
 VOLUME /opt/druid/var

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -53,17 +53,14 @@ RUN --mount=type=cache,target=/root/.m2 VERSION=$(mvn -B -q org.apache.maven.plu
 FROM busybox:1.34.1-glibc as busybox
 
 FROM $BASE_IMAGE
-ARG JDK_VERSION
-ARG BASE_IMAGE
 
 LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 
 COPY --from=busybox /bin/busybox /busybox/busybox
-RUN ["/busybox/busybox", "sh", "-c", "if [ $BASE_IMAGE = gcr.io/distroless/java$JDK_VERSION-debian11 ]; then \
+RUN ["/busybox/busybox", "sh", "-c", "if [ ! -x \"$(command -v bash)\" ]; then \
                                         exec /busybox/busybox --install /bin; \
                                       else \
-                                        rm /busybox/busybox \
-                                        && exit; \
+                                        rm /busybox/busybox; \
                                       fi;"]
 # Predefined builtin arg, see: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG TARGETARCH
@@ -73,7 +70,7 @@ ARG TARGETARCH
 # Although bash-static supports multiple platforms, but there's no need for us to support all those platform, amd64 and arm64 are enough.
 #
 ARG BASH_URL_BASE="https://github.com/robxu9/bash-static/releases/download/5.1.016-1.2.3"
-RUN if [ "$BASE_IMAGE" = "gcr.io/distroless/java$JDK_VERSION-debian11" ]; then \
+RUN if [ ! -x "$(command -v bash)" ]; then \
       if [ "$TARGETARCH" = "arm64" ]; then \
         BASH_URL="${BASH_URL_BASE}/bash-linux-aarch64" ; \
       elif [ "$TARGETARCH" = "amd64" ]; then \
@@ -86,12 +83,12 @@ RUN if [ "$BASE_IMAGE" = "gcr.io/distroless/java$JDK_VERSION-debian11" ]; then \
       && chmod 755 /bin/bash; \
     fi;
 
-RUN if [ "$BASE_IMAGE" = "gcr.io/distroless/java$JDK_VERSION-debian11" ]; then \
+RUN if [ ! -x "$(command -v useradd)" ]; then \
       addgroup -S -g 1000 druid \
       && adduser -S -u 1000 -D -H -h /opt/druid -s /bin/sh -g '' -G druid druid; \
     else \
-      groupadd --force --system --gid 1000 druid \
-      && useradd --system --uid 1000 -M --home /opt/druid --shell /bin/sh -c '' --gid druid druid; \
+      groupadd --system --gid 1000 druid \
+      && useradd --system --uid 1000 -M --home /opt/druid --shell /bin/sh -c '' --gid 1000 druid; \
     fi;
 
 COPY --chown=druid:druid --from=builder /opt /opt
@@ -105,10 +102,11 @@ RUN mkdir /opt/druid/var /opt/shared \
  && chown druid:druid /opt/druid/var /opt/shared \
  && chmod 775 /opt/druid/var /opt/shared
 
-# Install iproute2 library if busybox not installed
-RUN if [ "$BASE_IMAGE" != "gcr.io/distroless/java$JDK_VERSION-debian11" ]; then \
-     apt update \
-     && apt install -y iproute2; \
+# Install iproute2 to get the ip command needed to set config of druid.host IP address
+# Command needed in druid.sh Line 140;
+RUN if [ -x "$(command -v apt)" ] && [ ! -x "$(command -v ip)" ]; then \
+      apt update \
+      && apt install -y iproute2; \
     fi;
 
 USER druid


### PR DESCRIPTION
### Description
This PR allows us to Run a Debian based image with pre installed Bash. If no image is passed in build argument, it will build the General distroless/Busybox based image by default. We can pass `--build-arg IMAGE_NAME` to build the druid using other base images.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
