### PR TITLE
Filter Out Metrics with NoRecordedValue Flag Set

### DIFF
--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -176,7 +176,8 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
     return inputRows;
   }
 
-  private static boolean hasRecordedValue(NumberDataPoint d) {
+  private static boolean hasRecordedValue(NumberDataPoint d)
+  {
     return (d.getFlags() & DataPointFlags.FLAG_NO_RECORDED_VALUE_VALUE) == 0;
   }
 

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -146,15 +146,23 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       case SUM: {
         inputRows = new ArrayList<>(metric.getSum().getDataPointsCount());
         metric.getSum()
-            .getDataPointsList().stream().filter(OpenTelemetryMetricsProtobufReader::hasRecordedValue)
-            .forEach(dataPoint -> inputRows.add(parseNumberDataPoint(dataPoint, resourceAttributes, metricName)));
+            .getDataPointsList()
+            .forEach(dataPoint -> {
+              if (hasRecordedValue(dataPoint)) {
+                inputRows.add(parseNumberDataPoint(dataPoint, resourceAttributes, metricName));
+              }
+            });
         break;
       }
       case GAUGE: {
         inputRows = new ArrayList<>(metric.getGauge().getDataPointsCount());
         metric.getGauge()
-            .getDataPointsList().stream().filter(OpenTelemetryMetricsProtobufReader::hasRecordedValue)
-            .forEach(dataPoint -> inputRows.add(parseNumberDataPoint(dataPoint, resourceAttributes, metricName)));
+            .getDataPointsList()
+            .forEach(dataPoint -> {
+              if (hasRecordedValue(dataPoint)) {
+                inputRows.add(parseNumberDataPoint(dataPoint, resourceAttributes, metricName));
+              }
+            });
         break;
       }
       // TODO Support HISTOGRAM and SUMMARY metrics

--- a/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
+++ b/extensions-contrib/opentelemetry-extensions/src/main/java/org/apache/druid/data/input/opentelemetry/protobuf/OpenTelemetryMetricsProtobufReader.java
@@ -145,14 +145,16 @@ public class OpenTelemetryMetricsProtobufReader implements InputEntityReader
       case SUM: {
         inputRows = new ArrayList<>(metric.getSum().getDataPointsCount());
         metric.getSum()
-            .getDataPointsList()
+            // https://github.com/open-telemetry/opentelemetry-collector/blob/2ebe1e501f9a206237de1009a127f1a419ab3696/pdata/internal/data/protogen/metrics/v1/metrics.pb.go#L123-L139
+            .getDataPointsList().stream().filter(x -> (x.getFlags() & 1) != 1)
             .forEach(dataPoint -> inputRows.add(parseNumberDataPoint(dataPoint, resourceAttributes, metricName)));
         break;
       }
       case GAUGE: {
         inputRows = new ArrayList<>(metric.getGauge().getDataPointsCount());
         metric.getGauge()
-            .getDataPointsList()
+            // https://github.com/open-telemetry/opentelemetry-collector/blob/2ebe1e501f9a206237de1009a127f1a419ab3696/pdata/internal/data/protogen/metrics/v1/metrics.pb.go#L123-L139
+            .getDataPointsList().stream().filter(x -> (x.getFlags() & 1) != 1)
             .forEach(dataPoint -> inputRows.add(parseNumberDataPoint(dataPoint, resourceAttributes, metricName)));
         break;
       }


### PR DESCRIPTION
Metrics that contain the `NoRecordedValue` Flag are being written to Druid with a 0 value. We should properly handle them in the backend