### PR TITLE
[backport] Upgrade Avro to 1.11.1 (#14440)

### DIFF
--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
@@ -124,7 +124,11 @@ public class AvroFlattenerMaker implements ObjectFlatteners.FlattenerMaker<Gener
   @Override
   public Object getRootField(final GenericRecord record, final String key)
   {
-    return transformValue(record.get(key));
+    if (record.getSchema().getField(key) != null) {
+      return transformValue(record.get(key));
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -251,6 +251,10 @@ public class AvroFlattenerMakerTest
         list,
         flattener.getRootField(record, "someRecordArray")
     );
+    Assert.assertEquals(
+        null,
+        flattener.getRootField(record, "invalidField")
+    );
   }
 
   private void makeJsonPathExtractor_common(final SomeAvroDatum record, final AvroFlattenerMaker flattener)

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3608,7 +3608,7 @@ libraries:
 ---
 
 name: Apache Velocity Engine
-version: 2.2
+version: 2.3
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3626,7 +3626,7 @@ name: Apache Avro
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
-version: 1.9.2
+version: 1.11.1
 libraries:
   - org.apache.avro: avro
   - org.apache.avro: avro-mapred

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -446,14 +446,6 @@
   </suppress>
 
   <suppress>
-    <!-- (avro, parquet, integration-tests) we don't allow velocity templates to be uploaded by untrusted users -->
-    <notes><![CDATA[
-     file name: velocity-engine-core-2.2.jar:
-     ]]></notes>
-    <cve>CVE-2020-13936</cve>
-  </suppress>
-
-  <suppress>
      <!-- (ranger, ambari, and aliyun-oss) these vulnerabilities are legit, but their latest releases still use the vulnerable jackson version -->
      <notes><![CDATA[
      file name: jackson-xc-1.9.x.jar or jackson-jaxrs-1.9.x.jar

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
         <scala.library.version>2.13.9</scala.library.version>
         <avatica.version>1.17.0</avatica.version>
-        <avro.version>1.9.2</avro.version>
+        <avro.version>1.11.1</avro.version>
         <!-- sql/src/main/codegen/config.fmpp is based on a file from calcite-core, and needs to be
           updated when upgrading Calcite. Refer to the top-level comments in that file for details.
           Also, CalcitePlanner is a clone of Calcite's PlannerImpl and may require updates when


### PR DESCRIPTION
Cherry pick https://github.com/apache/druid/pull/14440 to upgrade `org.apache.avro:avro` to 1.11.1 to address [CVE-2020-13936](https://github.com/advisories/GHSA-59j4-wjwp-mw9m) for transitive dependency `org.apache.velocity:velocity-engine-core`.

