### PR TITLE
Revert "PRSP-3603 Bump org.xerial.snappy:snappy-java to latest version to address CVEs"

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3463,7 +3463,7 @@ name: snappy-java
 license_category: binary
 module: hadoop-client
 license_name: Apache License version 2.0
-version: 1.1.10.5
+version: 1.0.4.1
 libraries:
   - org.xerial.snappy: snappy-java
 notices:
@@ -3818,7 +3818,7 @@ name: snappy-java
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
-version: 1.1.10.5
+version: 1.1.8.4
 libraries:
   - org.xerial.snappy: snappy-java
 
@@ -5009,7 +5009,7 @@ libraries:
 
 name: snappy-java
 license_category: binary
-version: 1.1.10.5
+version: 1.1.8.4
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:

--- a/pom.xml
+++ b/pom.xml
@@ -739,7 +739,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.5</version>
+                <version>1.1.8.4</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Reverts confluentinc/druid#164

This reverts 185d6559eedefee2c0a17eda7cb5750b2997710c.
Middle managers stopped reporting the persist time metric. Reverting the commit we suspect caused the issue. 