### PR TITLE
OBSDATA-1697 Fix dist-used profile to use correct Hadoop version

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -841,7 +841,7 @@
                                         <argument>-l</argument>
                                         <argument>${settings.localRepository}</argument>
                                         <argument>-h</argument>
-                                        <argument>org.apache.hadoop:hadoop-client:2.8.5</argument>
+                                        <argument>org.apache.hadoop:hadoop-client:${hadoop.compile.version}</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions:druid-datasketches</argument>
                                         <argument>-c</argument>


### PR DESCRIPTION
### Description
The `dist-used` profile hard codes the `org.apache.hadoop:hadoop-client` version. This PR fixes it to use the `hadoop.compile.version` specified in the POM.

This PR has:

- [x] been self-reviewed.
