### PR TITLE
OBSDATA-3298: part 1: replace grpc protobuf to address CVEs

### DIFF
--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -47,7 +47,16 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+              <groupId>io.grpc</groupId>
+              <artifactId>grpc-protobuf</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+      <version>1.60.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.druid</groupId>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -149,7 +149,10 @@
               <artifactId>maven-dependency-plugin</artifactId>
               <configuration>
               <!-- analyze incorrectly flags this dependency as missing when omitted, and unused when declared -->
-                <ignoredDependencies>io.grpc:grpc-protobuf:1.60.0</ignoredDependencies>
+                <ignoredDependencies>io.grpc:grpc-protobuf</ignoredDependencies>
+                <!-- Transitive dependencies from opentelemetry but explicitly added to be shadowed -->
+                <ignoredUnusedDeclaredDependency>io.grpc:grpc-netty-shaded</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>com.google.guava:guava</ignoredUnusedDeclaredDependency>
               </configuration>
           </plugin>
         </plugins>

--- a/extensions-contrib/opencensus-extensions/pom.xml
+++ b/extensions-contrib/opencensus-extensions/pom.xml
@@ -142,6 +142,18 @@
     </dependency>
   </dependencies>
   <build>
+    <pluginManagement>
+        <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-dependency-plugin</artifactId>
+              <configuration>
+              <!-- analyze incorrectly flags this dependency as missing when omitted, and unused when declared -->
+                <ignoredDependencies>io.grpc:grpc-protobuf:1.60.0</ignoredDependencies>
+              </configuration>
+          </plugin>
+        </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Description
Update grpc brought by the outdated opencensus to fix 

[CVE-2023-32732](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32732)
[CVE-2023-32731](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-32731)
[CVE-2023-1428](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1428)

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
