### PR TITLE
[OBSDATA-3703] Add running task count metric for indexer pods

### DIFF
--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -66,6 +66,9 @@
 
   "worker/task/failed/count" : { "dimensions" : ["category", "workerVersion"], "type" : "count" },
   "worker/task/success/count" : { "dimensions" : ["category", "workerVersion"], "type" : "count" },
+  "worker/task/assigned/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+  "worker/task/running/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+  "worker/task/completed/count" : { "dimensions" : ["dataSource"], "type" : "count" },
   "worker/taskSlot/idle/count" : { "dimensions" : ["category", "workerVersion"], "type" : "gauge" },
   "worker/taskSlot/total/count" : { "dimensions" : ["category", "workerVersion"], "type" : "gauge" },
   "worker/taskSlot/used/count" : { "dimensions" : ["category", "workerVersion"], "type" : "gauge" },

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -179,9 +179,15 @@ public class WorkerTaskManager
     return completedTasks;
   }
 
-  public Map<String, TaskDetails> getRunningTasks() { return runningTasks; }
+  public Map<String, TaskDetails> getRunningTasks()
+  {
+    return runningTasks;
+  }
 
-  public Map<String, Task> getAssignedTasks() { return assignedTasks; }
+  public Map<String, Task> getAssignedTasks()
+  {
+    return assignedTasks;
+  }
 
   private void submitNoticeToExec(Notice notice)
   {
@@ -621,7 +627,8 @@ public class WorkerTaskManager
       this.location = TaskLocation.unknown();
     }
 
-    public String getDataSource() {
+    public String getDataSource()
+    {
       return task.getDataSource();
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -179,6 +179,10 @@ public class WorkerTaskManager
     return completedTasks;
   }
 
+  public Map<String, TaskDetails> getRunningTasks() { return runningTasks; }
+
+  public Map<String, Task> getAssignedTasks() { return assignedTasks; }
+
   private void submitNoticeToExec(Notice notice)
   {
     exec.execute(
@@ -602,7 +606,7 @@ public class WorkerTaskManager
     return !disabled.get();
   }
 
-  private static class TaskDetails
+  protected static class TaskDetails
   {
     private final Task task;
     private final long startTime;
@@ -615,6 +619,10 @@ public class WorkerTaskManager
       this.startTime = System.currentTimeMillis();
       this.status = TaskStatus.running(task.getId());
       this.location = TaskLocation.unknown();
+    }
+
+    public String getDataSource() {
+      return task.getDataSource();
     }
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManagerMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManagerMonitor.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.indexing.worker;
 
 import com.google.inject.Inject;
@@ -6,56 +25,57 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
 import org.apache.druid.query.DruidMetrics;
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-public class WorkerTaskManagerMonitor extends AbstractMonitor {
+public class WorkerTaskManagerMonitor extends AbstractMonitor
+{
+  private final WorkerTaskManager workerTaskManager;
+  private static final String WORKER_RUNNING_TASK_COUNT_METRICS = "worker/task/running/count";
+  private static final String WORKER_ASSIGNED_TASK_COUNT_METRIC = "worker/task/assigned/count";
+  private static final String WORKER_COMPLETED_TASK_COUNT_METRIC = "worker/task/completed/count";
 
-    private final WorkerTaskManager workerTaskManager;
+  @Inject
+  public WorkerTaskManagerMonitor(WorkerTaskManager workerTaskManager)
+  {
+    this.workerTaskManager = workerTaskManager;
+  }
 
-    private static final String WorkerRunningTaskCountMetric = "worker/task/running/count";
-    private static final String WorkerAssignedTaskCountMetric = "worker/task/assigned/count";
-    private static final String WorkerCompletedTaskCountMetric = "worker/task/completed/count";
+  @Override
+  public boolean doMonitor(ServiceEmitter emitter)
+  {
+    final Map<String, Integer> runningTasks, assignedTasks, completedTasks;
 
-    @Inject
-    public WorkerTaskManagerMonitor(WorkerTaskManager workerTaskManager)
-    {
-        this.workerTaskManager = workerTaskManager;
+    runningTasks = getDataSourceTasks(workerTaskManager.getRunningTasks(), WorkerTaskManager.TaskDetails::getDataSource);
+    assignedTasks = getDataSourceTasks(workerTaskManager.getAssignedTasks(), Task::getDataSource);
+    completedTasks = getDataSourceTasks(workerTaskManager.getCompletedTasks(), TaskAnnouncement::getTaskDataSource);
+
+    final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
+    emitWorkerTaskMetric(builder, emitter, WORKER_RUNNING_TASK_COUNT_METRICS, runningTasks);
+    emitWorkerTaskMetric(builder, emitter, WORKER_ASSIGNED_TASK_COUNT_METRIC, assignedTasks);
+    emitWorkerTaskMetric(builder, emitter, WORKER_COMPLETED_TASK_COUNT_METRIC, completedTasks);
+    return true;
+  }
+
+  public void emitWorkerTaskMetric(ServiceMetricEvent.Builder builder, ServiceEmitter emitter, String metricName, Map<String, Integer> dataSourceTaskMap)
+  {
+    for (Map.Entry<String, Integer> dataSourceTaskCount : dataSourceTaskMap.entrySet()) {
+      builder.setDimension(DruidMetrics.DATASOURCE, dataSourceTaskCount.getKey());
+      emitter.emit(builder.build(metricName, dataSourceTaskCount.getValue()));
     }
+  }
 
-    @Override
-    public boolean doMonitor(ServiceEmitter emitter) {
-        final Map<String, Integer> runningTasks, assignedTasks, completedTasks;
+  private <T> Map<String, Integer> getDataSourceTasks(Map<String, T> taskMap, Function<T, String> getDataSourceFunc)
+  {
+    String dataSource;
+    final Map<String, Integer> dataSourceTaskMap = new HashMap<>();
 
-        runningTasks = getDataSourceTasks(workerTaskManager.getRunningTasks(), WorkerTaskManager.TaskDetails::getDataSource);
-        assignedTasks = getDataSourceTasks(workerTaskManager.getAssignedTasks(), Task::getDataSource);
-        completedTasks = getDataSourceTasks(workerTaskManager.getCompletedTasks(), TaskAnnouncement::getTaskDataSource);
-
-        final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
-        emitWorkerTaskMetric(builder, emitter, WorkerRunningTaskCountMetric, runningTasks);
-        emitWorkerTaskMetric(builder, emitter, WorkerAssignedTaskCountMetric, assignedTasks);
-        emitWorkerTaskMetric(builder, emitter, WorkerCompletedTaskCountMetric, completedTasks);
-        return true;
+    for (Map.Entry<String, T> task : taskMap.entrySet()) {
+      dataSource = getDataSourceFunc.apply(task.getValue());
+      dataSourceTaskMap.putIfAbsent(dataSource, 0);
+      dataSourceTaskMap.put(dataSource, dataSourceTaskMap.get(dataSource) + 1);
     }
-
-    public void emitWorkerTaskMetric(ServiceMetricEvent.Builder builder, ServiceEmitter emitter, String metricName, Map<String, Integer> dataSourceTaskMap){
-        for (Map.Entry<String, Integer> dataSourceTaskCount : dataSourceTaskMap.entrySet()) {
-            builder.setDimension(DruidMetrics.DATASOURCE, dataSourceTaskCount.getKey());
-            emitter.emit(builder.build(metricName, dataSourceTaskCount.getValue()));
-        }
-    }
-
-    private <T> Map<String, Integer> getDataSourceTasks(Map<String, T> taskMap, Function<T, String> getDataSourceFunc) {
-        String dataSource;
-        final Map<String, Integer> dataSourceTaskMap = new HashMap<>();
-
-        for (Map.Entry<String, T> task : taskMap.entrySet()) {
-            dataSource = getDataSourceFunc.apply(task.getValue());
-            dataSourceTaskMap.putIfAbsent(dataSource, 0);
-            dataSourceTaskMap.put(dataSource, dataSourceTaskMap.get(dataSource) + 1);
-        }
-        return dataSourceTaskMap;
-    }
+    return dataSourceTaskMap;
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManagerMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManagerMonitor.java
@@ -1,0 +1,61 @@
+package org.apache.druid.indexing.worker;
+
+import com.google.inject.Inject;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.java.util.metrics.AbstractMonitor;
+import org.apache.druid.query.DruidMetrics;
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class WorkerTaskManagerMonitor extends AbstractMonitor {
+
+    private final WorkerTaskManager workerTaskManager;
+
+    private static final String WorkerRunningTaskCountMetric = "worker/task/running/count";
+    private static final String WorkerAssignedTaskCountMetric = "worker/task/assigned/count";
+    private static final String WorkerCompletedTaskCountMetric = "worker/task/completed/count";
+
+    @Inject
+    public WorkerTaskManagerMonitor(WorkerTaskManager workerTaskManager)
+    {
+        this.workerTaskManager = workerTaskManager;
+    }
+
+    @Override
+    public boolean doMonitor(ServiceEmitter emitter) {
+        final Map<String, Integer> runningTasks, assignedTasks, completedTasks;
+
+        runningTasks = getDataSourceTasks(workerTaskManager.getRunningTasks(), WorkerTaskManager.TaskDetails::getDataSource);
+        assignedTasks = getDataSourceTasks(workerTaskManager.getAssignedTasks(), Task::getDataSource);
+        completedTasks = getDataSourceTasks(workerTaskManager.getCompletedTasks(), TaskAnnouncement::getTaskDataSource);
+
+        final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
+        emitWorkerTaskMetric(builder, emitter, WorkerRunningTaskCountMetric, runningTasks);
+        emitWorkerTaskMetric(builder, emitter, WorkerAssignedTaskCountMetric, assignedTasks);
+        emitWorkerTaskMetric(builder, emitter, WorkerCompletedTaskCountMetric, completedTasks);
+        return true;
+    }
+
+    public void emitWorkerTaskMetric(ServiceMetricEvent.Builder builder, ServiceEmitter emitter, String metricName, Map<String, Integer> dataSourceTaskMap){
+        for (Map.Entry<String, Integer> dataSourceTaskCount : dataSourceTaskMap.entrySet()) {
+            builder.setDimension(DruidMetrics.DATASOURCE, dataSourceTaskCount.getKey());
+            emitter.emit(builder.build(metricName, dataSourceTaskCount.getValue()));
+        }
+    }
+
+    private <T> Map<String, Integer> getDataSourceTasks(Map<String, T> taskMap, Function<T, String> getDataSourceFunc) {
+        String dataSource;
+        final Map<String, Integer> dataSourceTaskMap = new HashMap<>();
+
+        for (Map.Entry<String, T> task : taskMap.entrySet()) {
+            dataSource = getDataSourceFunc.apply(task.getValue());
+            dataSourceTaskMap.putIfAbsent(dataSource, 0);
+            dataSourceTaskMap.put(dataSource, dataSourceTaskMap.get(dataSource) + 1);
+        }
+        return dataSourceTaskMap;
+    }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerMonitorTest.java
@@ -1,21 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.indexing.worker;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.discovery.DruidLeaderClient;
-import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.indexing.common.TaskToolbox;
-import org.apache.druid.indexing.common.TestUtils;
-import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.config.TaskConfig;
-import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
-import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.indexing.overlord.TaskRunner;
-import org.apache.druid.indexing.overlord.http.OverlordTest;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
-import org.apache.druid.query.Query;
-import org.apache.druid.query.QueryRunner;
-import org.apache.druid.server.metrics.TaskSlotCountStatsMonitor;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,7 +47,8 @@ public class WorkerTaskManagerMonitorTest
   private TaskAnnouncement taskAnnouncement;
 
   @Before
-  public void setUp(){
+  public void setUp()
+  {
     task = createMock(Task.class);
     EasyMock.expect(task.getDataSource()).andReturn("dummy_DS1");
     EasyMock.replay(task);
@@ -51,7 +61,8 @@ public class WorkerTaskManagerMonitorTest
     taskRunner = createMock(TaskRunner.class);
     taskConfig = createMock(TaskConfig.class);
     overlordClient = createMock(DruidLeaderClient.class);
-    workerTaskManager = new WorkerTaskManager(jsonMapper, taskRunner, taskConfig, overlordClient){
+    workerTaskManager = new WorkerTaskManager(jsonMapper, taskRunner, taskConfig, overlordClient)
+    {
       @Override
       public Map<String, TaskDetails> getRunningTasks()
       {
@@ -60,7 +71,7 @@ public class WorkerTaskManagerMonitorTest
         return runningTasks;
       }
       @Override
-      public Map<String,TaskAnnouncement> getCompletedTasks()
+      public Map<String, TaskAnnouncement> getCompletedTasks()
       {
         Map<String, TaskAnnouncement> completedTasks = new HashMap<>();
         completedTasks.put("taskId2", taskAnnouncement);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerMonitorTest.java
@@ -1,0 +1,90 @@
+package org.apache.druid.indexing.worker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.discovery.DruidLeaderClient;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.common.TestUtils;
+import org.apache.druid.indexing.common.actions.TaskActionClient;
+import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.overlord.TaskRunner;
+import org.apache.druid.indexing.overlord.http.OverlordTest;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryRunner;
+import org.apache.druid.server.metrics.TaskSlotCountStatsMonitor;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.easymock.EasyMock.createMock;
+
+public class WorkerTaskManagerMonitorTest
+{
+  private WorkerTaskManager workerTaskManager;
+  private TaskRunner taskRunner;
+  private ObjectMapper jsonMapper;
+  private TaskConfig taskConfig;
+  private DruidLeaderClient overlordClient;
+  private Task task;
+  private WorkerTaskManager.TaskDetails taskDetails;
+  private TaskAnnouncement taskAnnouncement;
+
+  @Before
+  public void setUp(){
+    task = createMock(Task.class);
+    EasyMock.expect(task.getDataSource()).andReturn("dummy_DS1");
+    EasyMock.replay(task);
+    taskDetails = createMock(WorkerTaskManager.TaskDetails.class);
+    EasyMock.expect(taskDetails.getDataSource()).andReturn("dummy_DS2");
+    EasyMock.replay(taskDetails);
+    taskAnnouncement = createMock(TaskAnnouncement.class);
+    EasyMock.expect(taskAnnouncement.getTaskDataSource()).andReturn("dummy_DS3");
+    EasyMock.replay(taskAnnouncement);
+    taskRunner = createMock(TaskRunner.class);
+    taskConfig = createMock(TaskConfig.class);
+    overlordClient = createMock(DruidLeaderClient.class);
+    workerTaskManager = new WorkerTaskManager(jsonMapper, taskRunner, taskConfig, overlordClient){
+      @Override
+      public Map<String, TaskDetails> getRunningTasks()
+      {
+        Map<String, TaskDetails> runningTasks = new HashMap<>();
+        runningTasks.put("taskId1", taskDetails);
+        return runningTasks;
+      }
+      @Override
+      public Map<String,TaskAnnouncement> getCompletedTasks()
+      {
+        Map<String, TaskAnnouncement> completedTasks = new HashMap<>();
+        completedTasks.put("taskId2", taskAnnouncement);
+        return completedTasks;
+      }
+      @Override
+      public Map<String, Task> getAssignedTasks()
+      {
+        Map<String, Task> assignedTasks = new HashMap<>();
+        assignedTasks.put("taskId3", task);
+        return assignedTasks;
+      }
+    };
+  }
+
+  @Test
+  public void testWorkerTaskManagerMonitor()
+  {
+    final WorkerTaskManagerMonitor monitor = new WorkerTaskManagerMonitor(workerTaskManager);
+    final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
+    monitor.doMonitor(emitter);
+    Assert.assertEquals(3, emitter.getEvents().size());
+    emitter.verifyValue("worker/task/running/count", 1);
+    emitter.verifyValue("worker/task/assigned/count", 1);
+    emitter.verifyValue("worker/task/completed/count", 1);
+  }
+}


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/OBSDATA-3703

In druid indexers we often see an issue with distribution of tasks accross indexers which results in slow ingestion 
This metric ould provide more visibility on the distribution of tasks accross indexers and help to find the root cause for the slow ingestion

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
