### PR TITLE
[Backport] Remove CVEs by upgrading dependencies

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3441,7 +3441,7 @@ name: PostgreSQL JDBC Driver
 license_category: binary
 module: extensions/druid-lookups-cached-single
 license_name: BSD-2-Clause License
-version: 42.6.0
+version: 42.7.2
 copyright: PostgreSQL Global Development Group
 license_file_path: licenses/bin/postgresql.BSD2
 libraries:
@@ -3453,7 +3453,7 @@ name: PostgreSQL JDBC Driver
 license_category: binary
 module: extensions/druid-lookups-cached-global
 license_name: BSD-2-Clause License
-version: 42.6.0
+version: 42.7.2
 copyright: PostgreSQL Global Development Group
 license_file_path: licenses/bin/postgresql.BSD2
 libraries:
@@ -3465,7 +3465,7 @@ name: PostgreSQL JDBC Driver
 license_category: binary
 module: extensions/postgresql-metadata-storage
 license_name: BSD-2-Clause License
-version: 42.6.0
+version: 42.7.2
 copyright: PostgreSQL Global Development Group
 license_file_path: licenses/bin/postgresql.BSD2
 libraries:

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -963,7 +963,7 @@ name: org.bitbucket.b_c jose4j
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 0.9.3
+version: 0.9.6
 libraries:
   - org.bitbucket.b_c: jose4j
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -505,7 +505,7 @@ name: Apache Commons Codec
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.13
+version: 1.16.1
 libraries:
   - commons-codec: commons-codec
 notices:
@@ -630,7 +630,7 @@ name: Apache Commons Compress
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.24.0
+version: 1.26.0
 libraries:
   - org.apache.commons: commons-compress
 notices:

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
             <dependency>
                 <groupId>org.bitbucket.b_c</groupId>
                 <artifactId>jose4j</artifactId>
-                <version>0.9.3</version>
+                <version>0.9.6</version>
             </dependency>
             <!-- transitive dependency of kafka-clientorg.apache.calcite:calcite-testkit
             and kafka-protobuf-provider

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <netty4.version>4.1.100.Final</netty4.version>
-        <postgresql.version>42.6.0</postgresql.version>
+        <postgresql.version>42.7.2</postgresql.version>
         <protobuf.version>3.24.0</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>
         <slf4j.version>1.7.36</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.13</version>
+                <version>1.16.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -570,7 +570,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.24.0</version>
+                <version>1.26.0</version>
             </dependency>
             <dependency>
                 <groupId>org.tukaani</groupId>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -81,6 +81,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>
+    <!-- commons-codec is an optional dependency of commons-compress starting with 1.26.0 which we require at runtime -->
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>


### PR DESCRIPTION
Description:

This PR fixes 3 CVEs present in the current image.
It backports these PRs from the upstream apache/druid:
[update common-compress to address CVE-2024-25710 CVE-2024-26308 #16009](https://github.com/apache/druid/pull/16009)
[update jose4j and corresponding license file #16078](https://github.com/apache/druid/pull/16078)
[Bump org.postgresql:postgresql from 42.6.0 to 42.7.2](https://github.com/apache/druid/pull/15931)

List of CVEs which are getting fixed:
https://avd.aquasec.com/nvd/2024/cve-2024-1597/
https://avd.aquasec.com/nvd/2023/cve-2023-51775/
https://avd.aquasec.com/nvd/2024/cve-2024-26308/
https://avd.aquasec.com/nvd/2024/cve-2024-25710/

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
